### PR TITLE
XMLRPC-API: Add struct and array identification

### DIFF
--- a/projects/typescript-xmlrpc/src/lib/deserializer.spec.ts
+++ b/projects/typescript-xmlrpc/src/lib/deserializer.spec.ts
@@ -21,6 +21,19 @@ describe('Deserializer', () => {
     expect(result).toEqual({value: 'South Dakota'});
   });
 
+  it('method response with int', () => {
+    const goodInput = `<?xml version="1.0"?>
+<methodResponse>
+    <params>
+        <param>
+            <value><i4>10</i4></value>
+            </param>
+        </params>
+    </methodResponse>`;
+    const result = deserialize(goodInput);
+    expect(result).toEqual({value: 10});
+  });
+
   it('method response with true bool', () => {
     const goodInput = `<?xml version="1.0"?>
 <methodResponse>

--- a/projects/typescript-xmlrpc/src/lib/deserializer.spec.ts
+++ b/projects/typescript-xmlrpc/src/lib/deserializer.spec.ts
@@ -9,88 +9,43 @@ describe('Deserializer', () => {
   });
 
   it('method response with string', () => {
-    const goodInput = `<?xml version="1.0"?>
-<methodResponse>
-    <params>
-        <param>
-            <value><string>South Dakota</string></value>
-            </param>
-        </params>
-    </methodResponse>`;
+    // eslint-disable-next-line max-len
+    const goodInput = `<?xml version="1.0"?><methodResponse><params><param><value><string>South Dakota</string></value></param></params></methodResponse>`;
     const result = deserialize(goodInput);
     expect(result).toEqual({value: 'South Dakota'});
   });
 
   it('method response with int', () => {
-    const goodInput = `<?xml version="1.0"?>
-<methodResponse>
-    <params>
-        <param>
-            <value><i4>10</i4></value>
-            </param>
-        </params>
-    </methodResponse>`;
+    // eslint-disable-next-line max-len
+    const goodInput = `<?xml version="1.0"?><methodResponse><params><param><value><i4>10</i4></value></param></params></methodResponse>`;
     const result = deserialize(goodInput);
     expect(result).toEqual({value: 10});
   });
 
   it('method response with true bool', () => {
-    const goodInput = `<?xml version="1.0"?>
-<methodResponse>
-    <params>
-        <param>
-            <value><boolean>1</boolean></value>
-            </param>
-        </params>
-    </methodResponse>`;
+    // eslint-disable-next-line max-len
+    const goodInput = `<?xml version="1.0"?><methodResponse><params><param><value><boolean>1</boolean></value></param></params></methodResponse>`;
     const result = deserialize(goodInput);
     expect(result).toEqual({value: true});
   });
 
   it('method response with false bool', () => {
-    const goodInput = `<?xml version="1.0"?>
-<methodResponse>
-    <params>
-        <param>
-            <value><boolean>0</boolean></value>
-            </param>
-        </params>
-    </methodResponse>`;
+    // eslint-disable-next-line max-len
+    const goodInput = `<?xml version="1.0"?><methodResponse><params><param><value><boolean>0</boolean></value></param></params></methodResponse>`;
     const result = deserialize(goodInput);
     expect(result).toEqual({value: false});
   });
 
   it('method response with invalid bool', () => {
-    const goodInput = `<?xml version="1.0"?>
-<methodResponse>
-    <params>
-        <param>
-            <value><boolean>text</boolean></value>
-            </param>
-        </params>
-    </methodResponse>`;
+    // eslint-disable-next-line max-len
+    const goodInput = `<?xml version="1.0"?><methodResponse><params><param><value><boolean>text</boolean></value></param></params></methodResponse>`;
     const result = deserialize(goodInput);
     expect(result).toEqual(applicationError);
   });
 
   it('fault response', () => {
-    const goodInput = `<?xml version="1.0"?>
-<methodResponse>
-    <fault>
-        <value>
-            <struct>
-                <member>
-                    <name>faultCode</name>
-                    <value><int>4</int></value>
-                    </member>
-                <member>
-                    <name>faultString</name>
-                    <value><string>Too many parameters.</string></value>
-                    </member>
-                </struct>
-            </value>
-        </fault>
-    </methodResponse>`;
+    // eslint-disable-next-line max-len
+    const goodInput = `<?xml version="1.0"?><methodResponse><fault><value><struct><member><name>faultCode</name><value><int>4</int></value></member><member><name>faultString</name><value><string>Too many parameters.</string></value></member></struct></value></fault></methodResponse>`;
     const result = deserialize(goodInput);
     expect(result).toEqual({faultCode: 4, faultString: 'Too many parameters.'});
   });

--- a/projects/typescript-xmlrpc/src/lib/deserializer.ts
+++ b/projects/typescript-xmlrpc/src/lib/deserializer.ts
@@ -158,7 +158,7 @@ function convertValue(element: Element): XmlRpcTypes {
     case 'i4':
     case 'int':
       const possibleInt = parseInt(valueChildren[0].innerHTML, 10);
-      if (possibleInt) {
+      if (typeof possibleInt === 'number') {
         return possibleInt;
       }
       throw new Error('value of type int was impossible to parse to an int!');

--- a/projects/typescript-xmlrpc/src/lib/typescript-xmlrpc.service.ts
+++ b/projects/typescript-xmlrpc/src/lib/typescript-xmlrpc.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { serializeMethodCall } from './serializer';
-import {MethodFault, MethodResponse, XmlRpcTypes} from './xmlrpc-types';
+import {MethodFault, MethodResponse, XmlRpcArray, XmlRpcStruct, XmlRpcTypes} from './xmlrpc-types';
 import { deserialize } from './deserializer';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -21,6 +21,14 @@ export class AngularXmlrpcService {
 
   static instanceOfMethodFault(object: any): object is MethodFault {
     return 'faultCode' in object && 'faultString' in object;
+  }
+
+  static instanceOfXmlRpcStruct(object: XmlRpcTypes): object is XmlRpcStruct {
+    return object !== null && typeof object === 'object' && Object.keys(object).length === 1 && 'members' in object
+  }
+
+  static instanceOfXmlRpcArray(object: XmlRpcTypes): object is XmlRpcArray {
+    return object !== null && typeof object === 'object' && Object.keys(object).length === 1 && 'data' in object
   }
 
   constructor(http: HttpClient) {


### PR DESCRIPTION
This PR does two things:

- Add methods to enable consumers to identify XML-RPC Struct and Arrays.
- Fix a bug in the integer deserializer method that does not return a number in case the number is `0`.