### PR TITLE
Add page for ` cobbler hardlink`

### DIFF
--- a/projects/cobbler-api/src/lib/cobbler-api.service.spec.ts
+++ b/projects/cobbler-api/src/lib/cobbler-api.service.spec.ts
@@ -91,9 +91,15 @@ describe('CobblerApiService', () => {
     expect(service).toBeFalsy();
   });
 
-  xit('should execute the background_hardlink action on the Cobbler Server', () => {
-    service.background_hardlink('');
-    expect(service).toBeFalsy();
+  it('should execute the background_hardlink action on the Cobbler Server', () => {
+    // eslint-disable-next-line max-len
+    const methodResponse = `<?xml version='1.0'?><methodResponse><params><param><value><string>2022-09-30_203004_Hardlink_800c38f4e0424187aed6a6ffb6553ef8</string></value></param></params></methodResponse>`
+    const result = "2022-09-30_203004_Hardlink_800c38f4e0424187aed6a6ffb6553ef8"
+    service.background_hardlink('').subscribe(value => {
+      expect(value).toEqual(result)
+    });
+    const mockRequest = httpTestingController.expectOne('http://localhost/cobbler_api');
+    mockRequest.flush(methodResponse);
   });
 
   xit('should execute the background_validate_autoinstall_files action on the Cobbler Server',

--- a/projects/cobbler-api/src/lib/cobbler-api.service.ts
+++ b/projects/cobbler-api/src/lib/cobbler-api.service.ts
@@ -157,8 +157,9 @@ export class CobblerApiService {
   }
 
   background_hardlink(token: string): Observable<string> {
+    const hardlinkOptions: XmlRpcStruct = {members: []}
     return this.client
-      .methodCall('background_hardlink', [token])
+      .methodCall('background_hardlink', [hardlinkOptions, token])
       .pipe(
         map<MethodResponse | MethodFault, string>((data: MethodResponse | MethodFault) => {
           if (AngularXmlrpcService.instanceOfMethodResponse(data)) {

--- a/projects/cobbler-frontend/src/app/actions/hardlink/hardlink.component.html
+++ b/projects/cobbler-frontend/src/app/actions/hardlink/hardlink.component.html
@@ -1,0 +1,3 @@
+<h1>HARDLINK</h1>
+
+<button mat-button (click)="runHardlink()">Hardlink</button>

--- a/projects/cobbler-frontend/src/app/actions/hardlink/hardlink.component.spec.ts
+++ b/projects/cobbler-frontend/src/app/actions/hardlink/hardlink.component.spec.ts
@@ -1,0 +1,38 @@
+import {provideHttpClient} from '@angular/common/http';
+import {provideHttpClientTesting} from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {MatButtonModule} from '@angular/material/button';
+import {COBBLER_URL} from 'cobbler-api';
+
+import { HardlinkComponent } from './hardlink.component';
+
+describe('HardlinkComponent', () => {
+  let component: HardlinkComponent;
+  let fixture: ComponentFixture<HardlinkComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        HardlinkComponent,
+        MatButtonModule,
+      ],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: COBBLER_URL,
+          useValue: new URL('http://localhost/cobbler_api')
+        },
+      ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(HardlinkComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/cobbler-frontend/src/app/actions/hardlink/hardlink.component.ts
+++ b/projects/cobbler-frontend/src/app/actions/hardlink/hardlink.component.ts
@@ -1,0 +1,41 @@
+import {Component} from '@angular/core';
+import {MatButton} from '@angular/material/button';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {CobblerApiService} from 'cobbler-api';
+import {UserService} from '../../services/user.service';
+
+@Component({
+  selector: 'cobbler-hardlink',
+  standalone: true,
+  imports: [
+    MatButton
+  ],
+  templateUrl: './hardlink.component.html',
+  styleUrl: './hardlink.component.scss'
+})
+export class HardlinkComponent {
+
+  constructor(
+    public userService: UserService,
+    private cobblerApiService: CobblerApiService,
+    private _snackBar: MatSnackBar
+  ) {
+  }
+
+  runHardlink(): void {
+    this.cobblerApiService.background_hardlink(this.userService.token).subscribe(
+      value => {
+        // TODO
+      },
+      error => {
+        // HTML encode the error message since it originates from XML
+        this._snackBar.open(this.toHTML(error.message), 'Close');
+      });
+  }
+
+  toHTML(input: string): any {
+    // FIXME: Deduplicate method
+    return new DOMParser().parseFromString(input, 'text/html').documentElement.textContent;
+  }
+
+}

--- a/projects/cobbler-frontend/src/app/app-routing.module.ts
+++ b/projects/cobbler-frontend/src/app/app-routing.module.ts
@@ -2,6 +2,7 @@
 import { Routes } from '@angular/router';
 import { BuildISOComponent } from './actions/build-iso/build-iso.component';
 import { CheckSysComponent } from './actions/check-sys/check-sys.component';
+import {HardlinkComponent} from './actions/hardlink/hardlink.component';
 import { ImportDVDComponent } from './actions/import-dvd/import-dvd.component';
 import { RepoSyncComponent } from './actions/repo-sync/repo-sync.component';
 import {StatusComponent} from './actions/status/status.component';
@@ -48,6 +49,7 @@ export const routes: Routes = [
   {path: 'buildiso', component: BuildISOComponent, canActivate: [AuthGuardService]},
   {path: 'check', component: CheckSysComponent, canActivate: [AuthGuardService]},
   {path: 'status', component: StatusComponent, canActivate: [AuthGuardService]},
+  {path: 'hardlink', component: HardlinkComponent, canActivate: [AuthGuardService]},
   {path: 'events', component: AppEventsComponent, canActivate: [AuthGuardService]},
   {path: '404', component: NotFoundComponent},
   {path: '**', redirectTo: '/404'},

--- a/projects/cobbler-frontend/src/app/manage-menu/manage-menu.component.html
+++ b/projects/cobbler-frontend/src/app/manage-menu/manage-menu.component.html
@@ -132,6 +132,9 @@
       <a mat-list-item class="nav-link" [routerLink]="['/buildiso']"
         ><b class="symbol">&#9881;</b>Build ISO</a
       >
+      <a mat-list-item class="nav-link" [routerLink]="['/hardlink']">
+        <b class="symbol">&#9881;</b>Hardlink</a
+      >
       <mat-divider></mat-divider>
       <h2 matSubheader>Cobbler</h2>
       <a mat-list-item class="nav-link" [routerLink]="['/check']">


### PR DESCRIPTION
Fixes #55

This is a simple page for the `cobbler hardlink` command. It is just a single button on an empty page. Not very exiting so far.