### PR TITLE
CI: Push coverage into GH artifacts

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/container-build-push.yml
+++ b/.github/workflows/container-build-push.yml
@@ -18,7 +18,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:

--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -1,0 +1,81 @@
+name: Coverage Upload
+
+on:
+  workflow_run:
+    workflows: [Tests]
+    types:
+      - completed
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/github-script
+      # Based on: https://github.com/orgs/community/discussions/34652
+      - name: 'Download artifact'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifactXmlRpc = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "coverage-report-typescript-xmlrpc"
+            })[0];
+            let matchArtifactApi = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "coverage-report-cobbler-api"
+            })[0];
+            let matchArtifactFrontend = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "coverage-report-cobbler-frontend"
+            })[0];
+            let downloadXmlRpc = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifactXmlRpc.id,
+               archive_format: 'zip',
+            });
+            let downloadApi = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifactApi.id,
+               archive_format: 'zip',
+            });
+            let downloadFrontend = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifactFrontend.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/coverage-report-xmlrpc.zip`, Buffer.from(downloadXmlRpc.data));
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/coverage-report-api.zip`, Buffer.from(downloadApi.data));
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/coverage-report-frontend.zip`, Buffer.from(downloadFrontend.data));
+      - name: 'Unzip typescript-xmlrpc artifact'
+        run: unzip coverage-report-xmlrpc.zip
+      - name: 'Unzip cobbler-api artifact'
+        run: unzip coverage-report-api.zip
+      - name: 'Unzip cobbler-frontend artifact'
+        run: unzip coverage-report-frontend.zip
+      # https://github.com/actions/download-artifact
+      # - name: Download artifact
+      #   id: download-artifact
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     run-id: ${{ github.event.workflow_run.id }}
+      # https://github.com/codacy/codacy-coverage-reporter-action
+      # - name: Run codacy-coverage-reporter
+      #   uses: codacy/codacy-coverage-reporter-action@v1
+      #   with:
+      #     project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      #     coverage-reports: coverage.xml
+      - name: Publish Code Coverage Results
+        run: |
+          auth="--project-token ${{ secrets.CODACY_PROJECT_TOKEN }}"
+          commit_uuid="--commit-uuid ${{ github.event.workflow_run.head_sha }}"
+
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report $auth $commit_uuid -r coverage/typescript-xmlrpc/lcov.info --partial &&\
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report $auth $commit_uuid -r coverage/cobbler-api/lcov.info --partial &&\
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report $auth $commit_uuid -r coverage/cobbler-frontend/lcov.info --partial &&\
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) final $auth $commit_uuid

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Cache node modules
         uses: actions/cache@v1
         with:
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@4
       - name: Download Artifact
         uses: actions/download-artifact@master
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         node-version: [ 18.x ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Node ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
@@ -36,7 +36,7 @@ jobs:
       matrix:
         node-version: [ 18.x ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Node ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
@@ -57,7 +57,7 @@ jobs:
       matrix:
         node-version: [ 18.x ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Node ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache@v4
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache@v2
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -62,7 +62,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,10 +28,14 @@ jobs:
       - name: Build project typescript-xmlrpc
         run: npm run build typescript-xmlrpc
       - name: Test Project
-        run: npm run test:ci typescript-xmlrpc
-      - uses: codecov/codecov-action@v2
+        run: npm run test:ci typescript-xmlrpc --code-coverage
+      # https://github.com/actions/upload-artifact
+      - name: Upload coverage report to GH artifacts
+        uses: actions/upload-artifact@v4
         with:
-          flags: unit-typescript-xmlrpc
+          name: coverage-report-typescript-xmlrpc
+          path: coverage/typescript-xmlrpc/lcov.info
+          if-no-files-found: error
   unit-cobbler-api:
     runs-on: ubuntu-latest
     container:
@@ -53,10 +57,14 @@ jobs:
       - name: Build project cobbler-api
         run: npm run build cobbler-api
       - name: Test Project
-        run: npm run test:ci cobbler-api
-      - uses: codecov/codecov-action@v2
+        run: npm run test:ci cobbler-api --code-coverage
+      # https://github.com/actions/upload-artifact
+      - name: Upload coverage report to GH artifacts
+        uses: actions/upload-artifact@v4
         with:
-          flags: unit-cobbler-api
+          name: coverage-report-cobbler-api
+          path: coverage/cobbler-api/lcov.info
+          if-no-files-found: error
   unit-cobbler-frontend:
     runs-on: ubuntu-latest
     container:
@@ -80,10 +88,14 @@ jobs:
       - name: Build project
         run: npm run build cobbler-frontend
       - name: Test Project
-        run: npm run test:ci cobbler-frontend
-      - uses: codecov/codecov-action@v2
+        run: npm run test:ci cobbler-frontend --code-coverage
+      # https://github.com/actions/upload-artifact
+      - name: Upload coverage report to GH artifacts
+        uses: actions/upload-artifact@v4
         with:
-          flags: unit-cobbler-frontend
+          name: coverage-report-cobbler-frontend
+          path: coverage/cobbler-frontend/lcov.info
+          if-no-files-found: error
   e2e-cobbler-frontend:
     if: ${{ false }}  # disable for now; we don't have e2e tests currently
     runs-on: ubuntu-latest
@@ -109,6 +121,3 @@ jobs:
         run: npm run build cobbler-frontend
       - name: E2E Tests
         run: npm run e2e -- --configuration=ci
-      - uses: codecov/codecov-action@v2
-        with:
-          flags: e2e-cobbler-frontend

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,7 +17,7 @@ jobs:
         CHROME_BIN: /usr/bin/google-chrome
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -44,7 +44,7 @@ jobs:
         CHROME_BIN: /usr/bin/google-chrome
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -73,7 +73,7 @@ jobs:
         CHROME_BIN: /usr/bin/google-chrome
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -105,7 +105,7 @@ jobs:
         CHROME_BIN: /usr/bin/google-chrome
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
       env:
         CHROME_BIN: /usr/bin/google-chrome
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/cache@v2
         with:
           path: ~/.npm
@@ -43,7 +43,7 @@ jobs:
       env:
         CHROME_BIN: /usr/bin/google-chrome
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/cache@v2
         with:
           path: ~/.npm
@@ -72,7 +72,7 @@ jobs:
       env:
         CHROME_BIN: /usr/bin/google-chrome
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/cache@v2
         with:
           path: ~/.npm
@@ -104,7 +104,7 @@ jobs:
       env:
         CHROME_BIN: /usr/bin/google-chrome
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/cache@v2
         with:
           path: ~/.npm


### PR DESCRIPTION
Fixes #263

The upload to Codacy can only be tested directly on the `main` branch. As such the `coverage-upload.yml` is untested in the scope of this PR.