### PR TITLE
Items: Implement copy button inside the details view

### DIFF
--- a/projects/cobbler-frontend/src/app/common/dialog-item-copy/dialog-item-copy.component.html
+++ b/projects/cobbler-frontend/src/app/common/dialog-item-copy/dialog-item-copy.component.html
@@ -1,0 +1,21 @@
+<h1 mat-dialog-title>Copy {{ data.itemType }}</h1>
+<mat-dialog-content>
+  <mat-form-field class="form-field-full-width">
+    <mat-label>Old name</mat-label>
+    <input matInput readonly value="{{ data.itemName }}" />
+  </mat-form-field>
+
+  <mat-form-field class="form-field-full-width">
+    <mat-label>New name</mat-label>
+    <input
+      matInput
+      [(ngModel)]="dialogCloseSignal"
+      cdkFocusInitial
+      placeholder="New name"
+    />
+  </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button mat-button (click)="onNoClick()">Close</button>
+  <button mat-button [mat-dialog-close]="dialogCloseSignal()">Copy</button>
+</mat-dialog-actions>

--- a/projects/cobbler-frontend/src/app/common/dialog-item-copy/dialog-item-copy.component.scss
+++ b/projects/cobbler-frontend/src/app/common/dialog-item-copy/dialog-item-copy.component.scss
@@ -1,0 +1,3 @@
+.form-field-full-width {
+  width: 100%;
+}

--- a/projects/cobbler-frontend/src/app/common/dialog-item-copy/dialog-item-copy.component.spec.ts
+++ b/projects/cobbler-frontend/src/app/common/dialog-item-copy/dialog-item-copy.component.spec.ts
@@ -1,0 +1,39 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+
+import { DialogItemCopyComponent } from './dialog-item-copy.component';
+
+describe('DialogItemRenameComponent', () => {
+  let component: DialogItemCopyComponent;
+  let fixture: ComponentFixture<DialogItemCopyComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DialogItemCopyComponent, MatDialogModule, NoopAnimationsModule],
+      providers: [
+        {
+          provide: MatDialogRef,
+          useValue: {},
+        },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: { itemType: 'Test', itemName: 'test', itemUid: '' },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DialogItemCopyComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/cobbler-frontend/src/app/common/dialog-item-copy/dialog-item-copy.component.ts
+++ b/projects/cobbler-frontend/src/app/common/dialog-item-copy/dialog-item-copy.component.ts
@@ -1,0 +1,48 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  Inject,
+  model,
+} from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatButton, MatButtonModule } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+
+export interface DialogItemCopyData {
+  itemType: string;
+  itemName: string;
+  itemUid: string;
+}
+
+@Component({
+  selector: 'cobbler-dialog-item-copy',
+  standalone: true,
+  imports: [
+    MatDialogModule,
+    MatButtonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    FormsModule,
+  ],
+  templateUrl: './dialog-item-copy.component.html',
+  styleUrl: './dialog-item-copy.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DialogItemCopyComponent {
+  readonly dialogRef = inject(MatDialogRef<DialogItemCopyComponent>);
+  readonly dialogCloseSignal = model('');
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: DialogItemCopyData) {}
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+}

--- a/projects/cobbler-frontend/src/app/items/distro/edit/distro-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/distro/edit/distro-edit.component.html
@@ -11,7 +11,11 @@
       </button>
     </span>
     <span class="title-cell-button">
-      <button mat-icon-button (click)="this.copyDistro()" matTooltip="Copy">
+      <button
+        mat-icon-button
+        (click)="this.copyDistro(this.distro.uid, this.distro.name)"
+        matTooltip="Copy"
+      >
         <mat-icon>content_copy</mat-icon>
       </button>
     </span>

--- a/projects/cobbler-frontend/src/app/items/file/edit/file-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/file/edit/file-edit.component.html
@@ -11,7 +11,11 @@
       </button>
     </span>
     <span class="title-cell-button">
-      <button mat-icon-button (click)="this.copyFile()" matTooltip="Copy">
+      <button
+        mat-icon-button
+        (click)="this.copyFile(this.file.uid, this.file.name)"
+        matTooltip="Copy"
+      >
         <mat-icon>content_copy</mat-icon>
       </button>
     </span>

--- a/projects/cobbler-frontend/src/app/items/image/edit/image-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/image/edit/image-edit.component.html
@@ -11,7 +11,11 @@
       </button>
     </span>
     <span class="title-cell-button">
-      <button mat-icon-button (click)="this.copyImage()" matTooltip="Copy">
+      <button
+        mat-icon-button
+        (click)="this.copyImage(this.image.uid, this.image.name)"
+        matTooltip="Copy"
+      >
         <mat-icon>content_copy</mat-icon>
       </button>
     </span>

--- a/projects/cobbler-frontend/src/app/items/management-class/edit/management-class-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/management-class/edit/management-class-edit.component.html
@@ -11,7 +11,16 @@
       </button>
     </span>
     <span class="title-cell-button">
-      <button mat-icon-button (click)="this.copyProfile()" matTooltip="Copy">
+      <button
+        mat-icon-button
+        (click)="
+          this.copyMgmtClass(
+            this.managementClass.uid,
+            this.managementClass.name
+          )
+        "
+        matTooltip="Copy"
+      >
         <mat-icon>content_copy</mat-icon>
       </button>
     </span>

--- a/projects/cobbler-frontend/src/app/items/management-class/edit/management-class-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/management-class/edit/management-class-edit.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
   FormBuilder,
   FormControl,
@@ -8,6 +8,7 @@ import {
 import { MatOption } from '@angular/material/autocomplete';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
+import { MatDialog } from '@angular/material/dialog';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
@@ -16,6 +17,9 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltip } from '@angular/material/tooltip';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CobblerApiService, Mgmgtclass } from 'cobbler-api';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { DialogItemCopyComponent } from '../../../common/dialog-item-copy/dialog-item-copy.component';
 import { KeyValueEditorComponent } from '../../../common/key-value-editor/key-value-editor.component';
 import { MultiSelectComponent } from '../../../common/multi-select/multi-select.component';
 import { UserService } from '../../../services/user.service';
@@ -43,7 +47,11 @@ import Utils from '../../../utils';
   templateUrl: './management-class-edit.component.html',
   styleUrl: './management-class-edit.component.scss',
 })
-export class ManagementClassEditComponent implements OnInit {
+export class ManagementClassEditComponent implements OnInit, OnDestroy {
+  // Unsubscribe
+  private ngUnsubscribe = new Subject<void>();
+
+  // Form
   name: string;
   managementClass: Mgmgtclass;
   private readonly _formBuilder = inject(FormBuilder);
@@ -72,6 +80,7 @@ export class ManagementClassEditComponent implements OnInit {
     private cobblerApiService: CobblerApiService,
     private _snackBar: MatSnackBar,
     private router: Router,
+    @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
   }
@@ -80,9 +89,15 @@ export class ManagementClassEditComponent implements OnInit {
     this.refreshData();
   }
 
+  ngOnDestroy(): void {
+    this.ngUnsubscribe.next();
+    this.ngUnsubscribe.complete();
+  }
+
   refreshData(): void {
     this.cobblerApiService
       .get_mgmtclass(this.name, false, false, this.userService.token)
+      .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(
         (value) => {
           this.managementClass = value;
@@ -145,6 +160,7 @@ export class ManagementClassEditComponent implements OnInit {
   removeManagementClass(): void {
     this.cobblerApiService
       .remove_mgmtclass(this.name, this.userService.token, false)
+      .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(
         (value) => {
           if (value) {
@@ -168,18 +184,52 @@ export class ManagementClassEditComponent implements OnInit {
     this._snackBar.open('Not implemented at the moment!', 'Close');
   }
 
-  copyProfile(): void {
-    this.cobblerApiService
-      .copy_mgmtclass('', '', this.userService.token)
-      .subscribe(
-        (value) => {
-          // TODO
-        },
-        (error) => {
-          // HTML encode the error message since it originates from XML
-          this._snackBar.open(Utils.toHTML(error.message), 'Close');
-        },
-      );
+  copyMgmtClass(uid: string, name: string): void {
+    const dialogRef = this.dialog.open(DialogItemCopyComponent, {
+      data: {
+        itemType: 'Mangement Class',
+        itemName: name,
+        itemUid: uid,
+      },
+    });
+
+    dialogRef.afterClosed().subscribe((newItemName) => {
+      if (newItemName === undefined) {
+        // Cancel means we don't need to rename the management class
+        return;
+      }
+      this.cobblerApiService
+        .get_mgmtclass_handle(name, this.userService.token)
+        .pipe(takeUntil(this.ngUnsubscribe))
+        .subscribe(
+          (mgmtClassHandle) => {
+            this.cobblerApiService
+              .copy_mgmtclass(
+                mgmtClassHandle,
+                newItemName,
+                this.userService.token,
+              )
+              .pipe(takeUntil(this.ngUnsubscribe))
+              .subscribe(
+                (value) => {
+                  this.router.navigate([
+                    '/items',
+                    'management-class',
+                    newItemName,
+                  ]);
+                },
+                (error) => {
+                  // HTML encode the error message since it originates from XML
+                  this._snackBar.open(Utils.toHTML(error.message), 'Close');
+                },
+              );
+          },
+          (error) => {
+            // HTML encode the error message since it originates from XML
+            this._snackBar.open(Utils.toHTML(error.message), 'Close');
+          },
+        );
+    });
   }
 
   saveProfile(): void {

--- a/projects/cobbler-frontend/src/app/items/package/edit/package-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/package/edit/package-edit.component.html
@@ -11,7 +11,11 @@
       </button>
     </span>
     <span class="title-cell-button">
-      <button mat-icon-button (click)="this.copyPackage()" matTooltip="Copy">
+      <button
+        mat-icon-button
+        (click)="this.copyPackage(this.package.uid, this.package.name)"
+        matTooltip="Copy"
+      >
         <mat-icon>content_copy</mat-icon>
       </button>
     </span>

--- a/projects/cobbler-frontend/src/app/items/profile/edit/profile-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/profile/edit/profile-edit.component.html
@@ -11,7 +11,11 @@
       </button>
     </span>
     <span class="title-cell-button">
-      <button mat-icon-button (click)="this.copyProfile()" matTooltip="Copy">
+      <button
+        mat-icon-button
+        (click)="this.copyProfile(this.profile.uid, this.profile.name)"
+        matTooltip="Copy"
+      >
         <mat-icon>content_copy</mat-icon>
       </button>
     </span>

--- a/projects/cobbler-frontend/src/app/items/profile/edit/profile-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/profile/edit/profile-edit.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
   FormBuilder,
   FormControl,
@@ -8,6 +8,7 @@ import {
 import { MatOption } from '@angular/material/autocomplete';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
+import { MatDialog } from '@angular/material/dialog';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
@@ -16,6 +17,9 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltip } from '@angular/material/tooltip';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CobblerApiService, Profile } from 'cobbler-api';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { DialogItemCopyComponent } from '../../../common/dialog-item-copy/dialog-item-copy.component';
 import { KeyValueEditorComponent } from '../../../common/key-value-editor/key-value-editor.component';
 import { MultiSelectComponent } from '../../../common/multi-select/multi-select.component';
 import { UserService } from '../../../services/user.service';
@@ -43,7 +47,11 @@ import Utils from '../../../utils';
   templateUrl: './profile-edit.component.html',
   styleUrl: './profile-edit.component.scss',
 })
-export class ProfileEditComponent implements OnInit {
+export class ProfileEditComponent implements OnInit, OnDestroy {
+  // Unsubscribe
+  private ngUnsubscribe = new Subject<void>();
+
+  // Form
   name: string;
   profile: Profile;
   private readonly _formBuilder = inject(FormBuilder);
@@ -110,6 +118,7 @@ export class ProfileEditComponent implements OnInit {
     private cobblerApiService: CobblerApiService,
     private _snackBar: MatSnackBar,
     private router: Router,
+    @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
   }
@@ -118,9 +127,15 @@ export class ProfileEditComponent implements OnInit {
     this.refreshData();
   }
 
+  ngOnDestroy(): void {
+    this.ngUnsubscribe.next();
+    this.ngUnsubscribe.complete();
+  }
+
   refreshData(): void {
     this.cobblerApiService
       .get_profile(this.name, false, false, this.userService.token)
+      .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(
         (value) => {
           this.profile = value;
@@ -284,6 +299,7 @@ export class ProfileEditComponent implements OnInit {
   removeProfile(): void {
     this.cobblerApiService
       .remove_profile(this.name, this.userService.token, false)
+      .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(
         (value) => {
           if (value) {
@@ -307,18 +323,44 @@ export class ProfileEditComponent implements OnInit {
     this._snackBar.open('Not implemented at the moment!', 'Close');
   }
 
-  copyProfile(): void {
-    this.cobblerApiService
-      .copy_profile('', '', this.userService.token)
-      .subscribe(
-        (value) => {
-          // TODO
-        },
-        (error) => {
-          // HTML encode the error message since it originates from XML
-          this._snackBar.open(Utils.toHTML(error.message), 'Close');
-        },
-      );
+  copyProfile(uid: string, name: string): void {
+    const dialogRef = this.dialog.open(DialogItemCopyComponent, {
+      data: {
+        itemType: 'Profile',
+        itemName: name,
+        itemUid: uid,
+      },
+    });
+
+    dialogRef.afterClosed().subscribe((newItemName) => {
+      if (newItemName === undefined) {
+        // Cancel means we don't need to rename the profile
+        return;
+      }
+      this.cobblerApiService
+        .get_profile_handle(name, this.userService.token)
+        .pipe(takeUntil(this.ngUnsubscribe))
+        .subscribe(
+          (profileHandle) => {
+            this.cobblerApiService
+              .copy_profile(profileHandle, newItemName, this.userService.token)
+              .pipe(takeUntil(this.ngUnsubscribe))
+              .subscribe(
+                (value) => {
+                  this.router.navigate(['/items', 'profile', newItemName]);
+                },
+                (error) => {
+                  // HTML encode the error message since it originates from XML
+                  this._snackBar.open(Utils.toHTML(error.message), 'Close');
+                },
+              );
+          },
+          (error) => {
+            // HTML encode the error message since it originates from XML
+            this._snackBar.open(Utils.toHTML(error.message), 'Close');
+          },
+        );
+    });
   }
 
   saveProfile(): void {

--- a/projects/cobbler-frontend/src/app/items/repository/edit/repository-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/repository/edit/repository-edit.component.html
@@ -11,7 +11,11 @@
       </button>
     </span>
     <span class="title-cell-button">
-      <button mat-icon-button (click)="this.copyRepository()" matTooltip="Copy">
+      <button
+        mat-icon-button
+        (click)="this.copyRepository(this.repository.uid, this.repository.name)"
+        matTooltip="Copy"
+      >
         <mat-icon>content_copy</mat-icon>
       </button>
     </span>

--- a/projects/cobbler-frontend/src/app/items/system/edit/system-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/system/edit/system-edit.component.html
@@ -11,7 +11,11 @@
       </button>
     </span>
     <span class="title-cell-button">
-      <button mat-icon-button (click)="this.copySystem()" matTooltip="Copy">
+      <button
+        mat-icon-button
+        (click)="this.copySystem(this.system.uid, this.system.name)"
+        matTooltip="Copy"
+      >
         <mat-icon>content_copy</mat-icon>
       </button>
     </span>


### PR DESCRIPTION
Fixes #351 

Example:

![grafik](https://github.com/user-attachments/assets/5d09e719-64b2-40be-9ef8-d6c30576fd47)

This dialog is reachable via the copy icon on the top right corner of the details view of an item.