### PR TITLE
XMLRPC-Client: Remove the need for custom list and map type

### DIFF
--- a/projects/typescript-xmlrpc/src/lib/deserializer.spec.ts
+++ b/projects/typescript-xmlrpc/src/lib/deserializer.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { deserialize } from './deserializer';
 import { applicationError } from './constants';
+import { MethodFault, MethodResponse } from './xmlrpc-types';
 
 describe('Deserializer', () => {
   beforeEach(() => {
@@ -11,28 +12,32 @@ describe('Deserializer', () => {
     // eslint-disable-next-line max-len
     const goodInput = `<?xml version="1.0"?><methodResponse><params><param><value><string>South Dakota</string></value></param></params></methodResponse>`;
     const result = deserialize(goodInput);
-    expect(result).toEqual({ value: 'South Dakota' });
+    const expected: MethodResponse = { value: 'South Dakota' };
+    expect(result).toEqual(expected);
   });
 
   it('method response with int', () => {
     // eslint-disable-next-line max-len
     const goodInput = `<?xml version="1.0"?><methodResponse><params><param><value><i4>10</i4></value></param></params></methodResponse>`;
     const result = deserialize(goodInput);
-    expect(result).toEqual({ value: 10 });
+    const expected: MethodResponse = { value: 10 };
+    expect(result).toEqual(expected);
   });
 
   it('method response with true bool', () => {
     // eslint-disable-next-line max-len
     const goodInput = `<?xml version="1.0"?><methodResponse><params><param><value><boolean>1</boolean></value></param></params></methodResponse>`;
     const result = deserialize(goodInput);
-    expect(result).toEqual({ value: true });
+    const expected: MethodResponse = { value: true };
+    expect(result).toEqual(expected);
   });
 
   it('method response with false bool', () => {
     // eslint-disable-next-line max-len
     const goodInput = `<?xml version="1.0"?><methodResponse><params><param><value><boolean>0</boolean></value></param></params></methodResponse>`;
     const result = deserialize(goodInput);
-    expect(result).toEqual({ value: false });
+    const expected: MethodResponse = { value: false };
+    expect(result).toEqual(expected);
   });
 
   it('method response with invalid bool', () => {
@@ -46,10 +51,11 @@ describe('Deserializer', () => {
     // eslint-disable-next-line max-len
     const goodInput = `<?xml version="1.0"?><methodResponse><fault><value><struct><member><name>faultCode</name><value><int>4</int></value></member><member><name>faultString</name><value><string>Too many parameters.</string></value></member></struct></value></fault></methodResponse>`;
     const result = deserialize(goodInput);
-    expect(result).toEqual({
+    const expected: MethodFault = {
       faultCode: 4,
       faultString: 'Too many parameters.',
-    });
+    };
+    expect(result).toEqual(expected);
   });
 
   it('process garbage like server errors', () => {

--- a/projects/typescript-xmlrpc/src/lib/serializer.spec.ts
+++ b/projects/typescript-xmlrpc/src/lib/serializer.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { serializeMethodCall } from './serializer';
+import { XmlRpcTypes } from './xmlrpc-types';
 
 describe('serializeMethodCall', () => {
   beforeEach(() => {
@@ -54,6 +55,14 @@ describe('serializeMethodCall', () => {
   it('function with array parameter', () => {
     // eslint-disable-next-line max-len
     const expectedResult = `<?xml version="1.0"?><methodCall><methodName>function_name</methodName><params><param><value><array><data><value><string>elem1</string></value><value><string>elem2</string></value></data></array></value></param></params></methodCall>`;
+    expect(serializeMethodCall('function_name', [['elem1', 'elem2']])).toBe(
+      expectedResult,
+    );
+  });
+
+  it('function with xmlrpc array parameter', () => {
+    // eslint-disable-next-line max-len
+    const expectedResult = `<?xml version="1.0"?><methodCall><methodName>function_name</methodName><params><param><value><array><data><value><string>elem1</string></value><value><string>elem2</string></value></data></array></value></param></params></methodCall>`;
     expect(
       serializeMethodCall('function_name', [{ data: ['elem1', 'elem2'] }]),
     ).toBe(expectedResult);
@@ -69,6 +78,19 @@ describe('serializeMethodCall', () => {
     expect(serializeMethodCall('function_name', [myexampledata])).toBe(
       expectedResult,
     );
+  });
+
+  it('function with map parameter', () => {
+    // eslint-disable-next-line max-len
+    const expectedResult = `<?xml version="1.0"?><methodCall><methodName>function_name</methodName><params><param><value><struct><member><name>data1</name><value><int>0</int></value></member><member><name>data2</name><value><string></string></value></member></struct></value></param></params></methodCall>`;
+    expect(
+      serializeMethodCall('function_name', [
+        new Map<string, XmlRpcTypes>([
+          ['data1', 0],
+          ['data2', ''],
+        ]),
+      ]),
+    ).toBe(expectedResult);
   });
 
   it('function with struct parameter', () => {

--- a/projects/typescript-xmlrpc/src/lib/serializer.ts
+++ b/projects/typescript-xmlrpc/src/lib/serializer.ts
@@ -1,6 +1,7 @@
 import { create } from 'xmlbuilder2';
 import { DateFormatter } from './date_formatter';
 import { XMLBuilder } from 'xmlbuilder2/lib/interfaces';
+import { Utils } from './utils';
 import { XmlRpcArray, XmlRpcStruct, XmlRpcTypes } from './xmlrpc-types';
 
 /**
@@ -59,14 +60,29 @@ function serializeValue(value: XmlRpcTypes, xml: XMLBuilder): void {
         appendBuffer(value as ArrayBuffer, xml);
         break;
       } else {
-        if ('data' in value) {
+        if (Utils.instanceOfXmlRpcArray(value)) {
           appendArray(
             value as XmlRpcArray,
             xml.ele('value').ele('array').ele('data'),
           );
           break;
         }
-        if ('members' in value) {
+        if (Array.isArray(value)) {
+          appendArray(
+            { data: value },
+            xml.ele('value').ele('array').ele('data'),
+          );
+          break;
+        }
+        if (value instanceof Map) {
+          const xmlrpcstruct = { members: [] };
+          for (let [key, val] of value) {
+            xmlrpcstruct.members.push({ name: key, value: val });
+          }
+          appendStruct(xmlrpcstruct, xml.ele('value').ele('struct'));
+          break;
+        }
+        if (Utils.instanceOfXmlRpcStruct(value)) {
           appendStruct(value as XmlRpcStruct, xml.ele('value').ele('struct'));
           break;
         }

--- a/projects/typescript-xmlrpc/src/lib/typescript-xmlrpc.service.spec.ts
+++ b/projects/typescript-xmlrpc/src/lib/typescript-xmlrpc.service.spec.ts
@@ -5,6 +5,7 @@ import {
   HttpClientTestingModule,
   HttpTestingController,
 } from '@angular/common/http/testing';
+import { MethodResponse } from './xmlrpc-types';
 
 describe('AngularXmlrpcService', () => {
   let service: AngularXmlrpcService;
@@ -39,8 +40,9 @@ describe('AngularXmlrpcService', () => {
     const testData = `<?xml version="1.0"?><methodResponse><params><param><value><string>3.2.1</string></value></param></params></methodResponse>`;
     service.configureService(new URL('http://localhost/cobbler_api'));
     const callObservable = service.methodCall('version');
+    const expected: MethodResponse = { value: '3.2.1' };
     callObservable.subscribe((value) => {
-      expect(value).toEqual({ value: '3.2.1' });
+      expect(value).toEqual(expected);
       done();
     });
     const req = httpTestingController.expectOne('http://localhost/cobbler_api');
@@ -84,7 +86,7 @@ describe('AngularXmlrpcService static methods', () => {
       ).toBe(parameter.resultResponse);
     });
 
-    it('instanceOfMethodFaullt', () => {
+    it('instanceOfMethodFault', () => {
       expect(AngularXmlrpcService.instanceOfMethodFault(parameter.data)).toBe(
         parameter.resultFault,
       );

--- a/projects/typescript-xmlrpc/src/lib/typescript-xmlrpc.service.ts
+++ b/projects/typescript-xmlrpc/src/lib/typescript-xmlrpc.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { serializeMethodCall } from './serializer';
+import { Utils } from './utils';
 import {
   MethodFault,
   MethodResponse,
@@ -25,29 +26,19 @@ export class AngularXmlrpcService {
   private headers: object;
 
   static instanceOfMethodResponse(object: object): object is MethodResponse {
-    return 'value' in object;
+    return Utils.instanceOfMethodResponse(object);
   }
 
   static instanceOfMethodFault(object: object): object is MethodFault {
-    return 'faultCode' in object && 'faultString' in object;
+    return Utils.instanceOfMethodFault(object);
   }
 
   static instanceOfXmlRpcStruct(object: XmlRpcTypes): object is XmlRpcStruct {
-    return (
-      object !== null &&
-      typeof object === 'object' &&
-      Object.keys(object).length === 1 &&
-      'members' in object
-    );
+    return Utils.instanceOfXmlRpcStruct(object);
   }
 
   static instanceOfXmlRpcArray(object: XmlRpcTypes): object is XmlRpcArray {
-    return (
-      object !== null &&
-      typeof object === 'object' &&
-      Object.keys(object).length === 1 &&
-      'data' in object
-    );
+    return Utils.instanceOfXmlRpcArray(object);
   }
 
   constructor(http: HttpClient) {

--- a/projects/typescript-xmlrpc/src/lib/utils.ts
+++ b/projects/typescript-xmlrpc/src/lib/utils.ts
@@ -1,0 +1,35 @@
+import {
+  MethodFault,
+  MethodResponse,
+  XmlRpcArray,
+  XmlRpcStruct,
+  XmlRpcTypes,
+} from './xmlrpc-types';
+
+export class Utils {
+  static instanceOfMethodResponse(object: object): object is MethodResponse {
+    return 'value' in object;
+  }
+
+  static instanceOfMethodFault(object: object): object is MethodFault {
+    return 'faultCode' in object && 'faultString' in object;
+  }
+
+  static instanceOfXmlRpcStruct(object: XmlRpcTypes): object is XmlRpcStruct {
+    return (
+      object !== null &&
+      typeof object === 'object' &&
+      Object.keys(object).length === 1 &&
+      'members' in object
+    );
+  }
+
+  static instanceOfXmlRpcArray(object: XmlRpcTypes): object is XmlRpcArray {
+    return (
+      object !== null &&
+      typeof object === 'object' &&
+      Object.keys(object).length === 1 &&
+      'data' in object
+    );
+  }
+}

--- a/projects/typescript-xmlrpc/src/lib/xmlrpc-types.ts
+++ b/projects/typescript-xmlrpc/src/lib/xmlrpc-types.ts
@@ -5,8 +5,13 @@ export type XmlRpcTypes =
   | Date
   | ArrayBuffer
   | XmlRpcStruct
-  | XmlRpcArray;
-export type MethodResponse = Param;
+  | Map<string, XmlRpcTypes>
+  | XmlRpcArray
+  | Array<XmlRpcTypes>;
+
+export interface MethodResponse {
+  value: XmlRpcTypes;
+}
 
 export interface MethodFault {
   faultCode: number;


### PR DESCRIPTION
Fixes #28  
Fixes #29  

This PR locally does not build anymore due to infinite types. It might be that we need to remove the custom list and array type fully to allow the TS compiler to work.