### PR TITLE
Feature: Add button to disable network boot

### DIFF
--- a/projects/cobbler-api/src/lib/cobbler-api.service.spec.ts
+++ b/projects/cobbler-api/src/lib/cobbler-api.service.spec.ts
@@ -2303,9 +2303,17 @@ describe('CobblerApiService', () => {
     expect(service).toBeFalsy();
   });
 
-  xit('should execute the disable_netboot action on the Cobbler Server', () => {
-    service.disable_netboot('', '');
-    expect(service).toBeFalsy();
+  it('should execute the disable_netboot action on the Cobbler Server', (done: DoneFn) => {
+    // eslint-disable-next-line max-len
+    const methodResponse = `<?xml version='1.0'?><methodResponse><params><param><value><boolean>1</boolean></value></param></params></methodResponse>`;
+    service.disable_netboot('', '').subscribe((value) => {
+      expect(value).toBeTrue();
+      done();
+    });
+    const mockRequest = httpTestingController.expectOne(
+      'http://localhost/cobbler_api',
+    );
+    mockRequest.flush(methodResponse);
   });
 
   xit('should execute the upload_log_data action on the Cobbler Server', () => {

--- a/projects/cobbler-api/src/lib/custom-types/settings.ts
+++ b/projects/cobbler-api/src/lib/custom-types/settings.ts
@@ -1,14 +1,5 @@
-export type Settings = V3_3_1 | V3_3_2 | V3_3_3 | V3_4_0;
-
-export interface V3_3_1 {
-  // TODO
-}
-
-export interface V3_3_2 {
-  // TODO
-}
-
-export interface V3_3_3 {
+// The Settings of the daemon. Some properties may be not available depending on the version of Cobbler running.
+export type Settings = {
   auto_migrate_settings: boolean;
   allow_duplicate_hostnames: boolean;
   allow_duplicate_ips: boolean;
@@ -27,6 +18,7 @@ export interface V3_3_3 {
   bootloaders_dir?: string;
   bootloaders_formats?: object;
   bootloaders_modules?: Array<string>;
+  // This setting was introduced with 3.3.1 and as such is missing on older versions of Cobbler.
   bootloaders_shim_folder?: string;
   bootloaders_shim_file?: string;
   bootloaders_ipxe_folder?: string;
@@ -56,6 +48,7 @@ export interface V3_3_3 {
   default_template_type: string;
   default_virt_bridge: string;
   default_virt_disk_driver?: string;
+  // This setting is a float starting with 3.3.3, beforehand this was an integer.
   default_virt_file_size: number;
   default_virt_ram: number;
   default_virt_type: string;
@@ -141,8 +134,9 @@ export interface V3_3_3 {
   windows_enabled?: boolean;
   windows_template_dir?: string;
   samba_distro_share?: string;
-}
-
-export interface V3_4_0 {
-  // TODO
-}
+  extra_settings_list: Array<string>;
+  // This setting was introduced with 3.3.5.
+  cache_enabled?: boolean;
+  // This setting was introduced with 3.3.5.
+  lazy_start?: boolean;
+};

--- a/projects/cobbler-frontend/src/app/items/system/edit/system-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/system/edit/system-edit.component.html
@@ -61,6 +61,18 @@
         <mat-icon>delete</mat-icon>
       </button>
     </span>
+    @if (showDisableNetboot && system !== undefined && system.netboot_enabled) {
+      <span class="title-cell-button">
+        <button
+          mat-icon-button
+          [disabled]="isEditMode"
+          (click)="disableNetboot()"
+          matTooltip="Disable Network Boot"
+        >
+          <mat-icon>do_not_disturb_on</mat-icon>
+        </button>
+      </span>
+    }
     @if (isEditMode) {
       <span class="title-cell-button">
         <button

--- a/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.html
@@ -34,6 +34,15 @@
           <mat-icon>edit</mat-icon>
           <span>Rename</span>
         </button>
+        @if (showDisableNetboot && element.netboot_enabled) {
+          <button
+            mat-menu-item
+            (click)="disableNetboot(element.uid, element.name)"
+          >
+            <mat-icon>do_not_disturb_on</mat-icon>
+            <span>Disable Network Boot</span>
+          </button>
+        }
         <button mat-menu-item (click)="deleteSystem(element.uid, element.name)">
           <mat-icon>delete</mat-icon>
           <span>Delete</span>


### PR DESCRIPTION
Fixes #384 

This adds a button to the system overview and detail view that lets one disable network boot for a specific machine. Since there is no API to enable network boot, this must be done manually in the detail view.