### PR TITLE
Cobbler-Frontend: Deduplicate the inherit button

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/projects/cobbler-frontend/src/app/items/distro/edit/distro-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/distro/edit/distro-edit.component.html
@@ -66,180 +66,112 @@
 </div>
 
 <form class="form-replicate" [formGroup]="distroReadonlyFormGroup">
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Name</mat-label>
-    <input matInput type="text" formControlName="name" [readonly]="true" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>UID</mat-label>
-    <input matInput type="text" formControlName="uid" [readonly]="true" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Last modified time</mat-label>
-    <input matInput type="text" formControlName="mtime" [readonly]="true" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Creation time</mat-label>
-    <input matInput type="text" formControlName="ctime" [readonly]="true" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Depth</mat-label>
-    <input matInput type="number" formControlName="depth" [readonly]="true" />
-  </mat-form-field>
-  <mat-checkbox
-    class="form-field-full-width"
-    formControlName="is_subobject"
-    [disableRipple]="true"
-    (click)="$event.preventDefault()"
-  >
-    Is Subobject?
-  </mat-checkbox>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Tree Build Time</mat-label>
-    <input
-      matInput
-      type="text"
-      formControlName="tree_build_time"
-      [readonly]="true"
-    />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Remote GRUB Initrd</mat-label>
-    <input
-      matInput
-      type="text"
-      formControlName="remote_grub_initrd"
-      [readonly]="true"
-    />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Remote GRUB Kernel</mat-label>
-    <input
-      matInput
-      type="text"
-      formControlName="remote_grub_kernel"
-      [readonly]="true"
-    />
-  </mat-form-field>
+  @for (input of distroReadonlyInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+    }
+  }
 </form>
 
 <form class="form-replicate" [formGroup]="distroFormGroup">
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Architecture</mat-label>
-    <input matInput type="text" formControlName="arch" />
-  </mat-form-field>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Automatic Installation Template Metadata"
-      formControlName="autoinstall_meta"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="autoinstall_meta_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="TFTP Boot Files"
-      formControlName="boot_files"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="boot_files_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Boot Loaders"
-      formControlName="boot_loaders"
-    ></cobbler-multi-select>
-    <mat-checkbox formControlName="boot_loaders_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Breed</mat-label>
-    <input matInput type="text" formControlName="breed" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Comment</mat-label>
-    <input matInput type="text" formControlName="comment" />
-  </mat-form-field>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Fetchable Files"
-      formControlName="fetchable_files"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="fetchable_files_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>kernel</mat-label>
-    <input matInput type="text" formControlName="kernel" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>initrd</mat-label>
-    <input matInput type="text" formControlName="initrd" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Remote Boot Initrd</mat-label>
-    <input matInput type="text" formControlName="remote_boot_initrd" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Remote Boot Kernel</mat-label>
-    <input matInput type="text" formControlName="remote_boot_kernel" />
-  </mat-form-field>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Kernel Options"
-      formControlName="kernel_options"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="kernel_options_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Kernel Options (Post Install)"
-      formControlName="kernel_options_post"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="kernel_options_post_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Management Classes"
-      formControlName="mgmt_classes"
-    ></cobbler-multi-select>
-    <mat-checkbox formControlName="mgmt_classes_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Operating System Version</mat-label>
-    <input matInput type="text" formControlName="os_version" />
-  </mat-form-field>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Owners"
-      formControlName="owners"
-    ></cobbler-multi-select>
-    <mat-checkbox formControlName="owners_inherited">Inherited</mat-checkbox>
-  </ng-container>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>RedHat Management Key</mat-label>
-    <input matInput type="text" formControlName="redhat_management_key" />
-  </mat-form-field>
-  <div class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Template Files"
-      formControlName="template_files"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="template_files_inherited">
-      Inherited
-    </mat-checkbox>
-  </div>
+  @for (input of distroEditableInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+      @case (CobblerInputChoices.MULTI_SELECT) {
+        <ng-container class="form-field-full-width">
+          <cobbler-multi-select
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-multi-select>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+      @case (CobblerInputChoices.KEY_VALUE) {
+        <ng-container class="form-field-full-width">
+          <cobbler-key-value-editor
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-key-value-editor>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+    }
+  }
   @if (isEditMode) {
-    <button mat-button (click)="saveDistro()">Save Distro</button>
+    <div>
+      <button mat-button (click)="saveDistro()">Save Distro</button>
+    </div>
   }
 </form>

--- a/projects/cobbler-frontend/src/app/items/distro/edit/distro-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/distro/edit/distro-edit.component.ts
@@ -27,6 +27,10 @@ import { MultiSelectComponent } from '../../../common/multi-select/multi-select.
 import { UserService } from '../../../services/user.service';
 import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
+import {
+  cobblerItemEditableData,
+  cobblerItemReadonlyData,
+} from '../../metadata';
 
 @Component({
   selector: 'cobbler-edit',
@@ -58,60 +62,7 @@ export class DistroEditComponent implements OnInit, OnDestroy {
 
   // Form Data
   distroReadonlyInputData: Array<CobblerInputData> = [
-    {
-      formControlName: 'name',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Name',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'uid',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'UID',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'mtime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Last modified time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'ctime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Creation time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'depth',
-      inputType: CobblerInputChoices.NUMBER,
-      label: 'Depth',
-      disabled: false,
-      readonly: true,
-      defaultValue: 0,
-      inherited: false,
-    },
-    {
-      formControlName: 'is_subobject',
-      inputType: CobblerInputChoices.CHECKBOX,
-      label: 'Is Subobject?',
-      disabled: false,
-      readonly: true,
-      defaultValue: false,
-      inherited: false,
-    },
+    ...cobblerItemReadonlyData,
     {
       formControlName: 'tree_build_time',
       inputType: CobblerInputChoices.TEXT,
@@ -141,6 +92,7 @@ export class DistroEditComponent implements OnInit, OnDestroy {
     },
   ];
   distroEditableInputData: Array<CobblerInputData> = [
+    ...cobblerItemEditableData,
     {
       formControlName: 'arch',
       inputType: CobblerInputChoices.TEXT,
@@ -181,15 +133,6 @@ export class DistroEditComponent implements OnInit, OnDestroy {
       formControlName: 'breed',
       inputType: CobblerInputChoices.TEXT,
       label: 'Breed',
-      disabled: true,
-      readonly: false,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'comment',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Comment',
       disabled: true,
       readonly: false,
       defaultValue: '',

--- a/projects/cobbler-frontend/src/app/items/distro/edit/distro-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/distro/edit/distro-edit.component.ts
@@ -2,7 +2,6 @@ import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
   AbstractControl,
   FormBuilder,
-  FormControl,
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
@@ -265,42 +264,12 @@ export class DistroEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
-    this.distroReadonlyInputData.forEach((value) => {
-      this.distroReadonlyFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.distroReadonlyFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
-    this.distroEditableInputData.forEach((value) => {
-      this.distroFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.distroFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
+    Utils.fillupItemFormGroup(
+      this.distroReadonlyFormGroup,
+      this.distroFormGroup,
+      this.distroReadonlyInputData,
+      this.distroEditableInputData,
+    );
   }
 
   ngOnInit(): void {

--- a/projects/cobbler-frontend/src/app/items/distro/edit/distro-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/distro/edit/distro-edit.component.ts
@@ -1,5 +1,6 @@
 import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
+  AbstractControl,
   FormBuilder,
   FormControl,
   FormsModule,
@@ -24,7 +25,7 @@ import { DialogItemCopyComponent } from '../../../common/dialog-item-copy/dialog
 import { KeyValueEditorComponent } from '../../../common/key-value-editor/key-value-editor.component';
 import { MultiSelectComponent } from '../../../common/multi-select/multi-select.component';
 import { UserService } from '../../../services/user.service';
-import Utils from '../../../utils';
+import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
 
 @Component({
@@ -49,80 +50,267 @@ import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-
   styleUrl: './distro-edit.component.scss',
 })
 export class DistroEditComponent implements OnInit, OnDestroy {
+  // Bring Enum to HTML scope
+  protected readonly CobblerInputChoices = CobblerInputChoices;
+
   // Unsubscribe
   private ngUnsubscribe = new Subject<void>();
+
+  // Form Data
+  distroReadonlyInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'name',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Name',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'uid',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'UID',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'mtime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Last modified time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'ctime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Creation time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'depth',
+      inputType: CobblerInputChoices.NUMBER,
+      label: 'Depth',
+      disabled: false,
+      readonly: true,
+      defaultValue: 0,
+      inherited: false,
+    },
+    {
+      formControlName: 'is_subobject',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Is Subobject?',
+      disabled: false,
+      readonly: true,
+      defaultValue: false,
+      inherited: false,
+    },
+    {
+      formControlName: 'tree_build_time',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Tree Build Time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'remote_grub_initrd',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Remote GRUB Initrd',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'remote_grub_kernel',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Remote GRUB Kernel',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+  ];
+  distroEditableInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'arch',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Architecture',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'autoinstall_meta',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Automatic Installation Template Metadata',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'boot_files',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'TFTP Boot Files',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'boot_loaders',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Boot Loaders',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+    {
+      formControlName: 'breed',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Breed',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'comment',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Comment',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'fetchable_files',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Fetchable Files',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'kernel',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Kernel',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'initrd',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Initrd',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'remote_boot_initrd',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Remote Boot Initrd',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'remote_boot_kernel',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Remote Boot Kernel',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'kernel_options',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Kernel Options',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'kernel_options_post',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Kernel Options (Post Install)',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'mgmt_classes',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Management Classes',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+    {
+      formControlName: 'os_version',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Operating System Version',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'owners',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Owners',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+    {
+      formControlName: 'redhat_management_key',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'RedHat Management Key',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'template_files',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Template Files',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+  ];
 
   // Form
   name: string;
   distro: Distro;
   private readonly _formBuilder = inject(FormBuilder);
-  distroReadonlyFormGroup = this._formBuilder.group({
-    name: new FormControl({ value: '', disabled: false }),
-    uid: new FormControl({ value: '', disabled: false }),
-    mtime: new FormControl({ value: '', disabled: false }),
-    ctime: new FormControl({ value: '', disabled: false }),
-    depth: new FormControl({ value: 0, disabled: false }),
-    is_subobject: new FormControl({ value: false, disabled: false }),
-    tree_build_time: new FormControl({ value: '', disabled: false }),
-    remote_grub_initrd: new FormControl({ value: '', disabled: false }),
-    remote_grub_kernel: new FormControl({ value: '', disabled: false }),
-  });
-  distroFormGroup = this._formBuilder.group({
-    arch: new FormControl({ value: '', disabled: true }),
-    breed: new FormControl({ value: '', disabled: true }),
-    comment: new FormControl({ value: '', disabled: true }),
-    kernel: new FormControl({ value: '', disabled: true }),
-    initrd: new FormControl({ value: '', disabled: true }),
-    remote_boot_initrd: new FormControl({ value: '', disabled: true }),
-    remote_boot_kernel: new FormControl({ value: '', disabled: true }),
-    os_version: new FormControl({ value: '', disabled: true }),
-    redhat_management_key: new FormControl({ value: '', disabled: true }),
-    boot_loaders: new FormControl({ value: [], disabled: true }),
-    boot_loaders_inherited: new FormControl({ value: false, disabled: true }),
-    owners: new FormControl({ value: [], disabled: true }),
-    owners_inherited: new FormControl({ value: false, disabled: true }),
-    mgmt_classes: new FormControl({ value: [], disabled: true }),
-    mgmt_classes_inherited: new FormControl({ value: false, disabled: true }),
-    autoinstall_meta: new FormControl({
-      value: new Map<string, any>(),
-      disabled: true,
-    }),
-    autoinstall_meta_inherited: new FormControl({
-      value: false,
-      disabled: true,
-    }),
-    boot_files: new FormControl({
-      value: new Map<string, any>(),
-      disabled: true,
-    }),
-    boot_files_inherited: new FormControl({ value: false, disabled: true }),
-    fetchable_files: new FormControl({
-      value: new Map<string, any>(),
-      disabled: true,
-    }),
-    fetchable_files_inherited: new FormControl({
-      value: false,
-      disabled: true,
-    }),
-    kernel_options: new FormControl({
-      value: new Map<string, any>(),
-      disabled: true,
-    }),
-    kernel_options_inherited: new FormControl({ value: false, disabled: true }),
-    kernel_options_post: new FormControl({
-      value: new Map<string, any>(),
-      disabled: true,
-    }),
-    kernel_options_post_inherited: new FormControl({
-      value: false,
-      disabled: true,
-    }),
-    template_files: new FormControl({
-      value: new Map<string, any>(),
-      disabled: true,
-    }),
-    template_files_inherited: new FormControl({ value: false, disabled: true }),
-  });
+  distroReadonlyFormGroup = this._formBuilder.group({});
+  distroFormGroup = this._formBuilder.group({});
   isEditMode: boolean = false;
 
   constructor(
@@ -134,40 +322,99 @@ export class DistroEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
+    this.distroReadonlyInputData.forEach((value) => {
+      this.distroReadonlyFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.distroReadonlyFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
+    this.distroEditableInputData.forEach((value) => {
+      this.distroFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.distroFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
   }
 
   ngOnInit(): void {
     this.refreshData();
     // Observables for inherited properties
-    this.distroFormGroup.controls.autoinstall_meta_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.distroFormGroup.controls.autoinstall_meta),
-    );
-    this.distroFormGroup.controls.boot_files_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.distroFormGroup.controls.boot_files),
-    );
-    this.distroFormGroup.controls.boot_loaders_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.distroFormGroup.controls.boot_loaders),
-    );
-    this.distroFormGroup.controls.fetchable_files_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.distroFormGroup.controls.fetchable_files),
-    );
-    this.distroFormGroup.controls.kernel_options_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.distroFormGroup.controls.kernel_options),
-    );
-    this.distroFormGroup.controls.kernel_options_post_inherited.valueChanges.subscribe(
-      this.getInheritObservable(
-        this.distroFormGroup.controls.kernel_options_post,
-      ),
-    );
-    this.distroFormGroup.controls.mgmt_classes_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.distroFormGroup.controls.mgmt_classes),
-    );
-    this.distroFormGroup.controls.owners_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.distroFormGroup.controls.owners),
-    );
-    this.distroFormGroup.controls.template_files_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.distroFormGroup.controls.template_files),
-    );
+    this.distroFormGroup
+      .get('autoinstall_meta_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.distroFormGroup.get('autoinstall_meta')),
+      );
+    this.distroFormGroup
+      .get('autoinstall_meta_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.distroFormGroup.get('autoinstall_meta')),
+      );
+    this.distroFormGroup
+      .get('boot_files_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.distroFormGroup.get('boot_files')),
+      );
+    this.distroFormGroup
+      .get('boot_loaders_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.distroFormGroup.get('boot_loaders')),
+      );
+    this.distroFormGroup
+      .get('fetchable_files_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.distroFormGroup.get('fetchable_files')),
+      );
+    this.distroFormGroup
+      .get('kernel_options_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.distroFormGroup.get('kernel_options')),
+      );
+    this.distroFormGroup
+      .get('kernel_options_post_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(
+          this.distroFormGroup.get('kernel_options_post'),
+        ),
+      );
+    this.distroFormGroup
+      .get('mgmt_classes_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.distroFormGroup.get('mgmt_classes')),
+      );
+    this.distroFormGroup
+      .get('owners_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.distroFormGroup.get('owners')),
+      );
+    this.distroFormGroup
+      .get('template_files_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.distroFormGroup.get('template_files')),
+      );
   }
 
   ngOnDestroy(): void {
@@ -175,7 +422,9 @@ export class DistroEditComponent implements OnInit, OnDestroy {
     this.ngUnsubscribe.complete();
   }
 
-  getInheritObservable(valueControl: FormControl): (value: boolean) => void {
+  getInheritObservable(
+    valueControl: AbstractControl,
+  ): (value: boolean) => void {
     return (value: boolean): void => {
       if (!this.isEditMode) {
         // If we are not in edit-mode we want to discard processing the event
@@ -193,153 +442,89 @@ export class DistroEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_distro(this.name, false, false, this.userService.token)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (value) => {
+      .subscribe({
+        next: (value) => {
           this.distro = value;
-          this.distroReadonlyFormGroup.controls.name.setValue(this.distro.name);
-          this.distroReadonlyFormGroup.controls.uid.setValue(this.distro.uid);
-          this.distroReadonlyFormGroup.controls.mtime.setValue(
-            Utils.floatToDate(this.distro.mtime).toString(),
+          this.distroReadonlyFormGroup.patchValue({
+            name: this.distro.name,
+            uid: this.distro.uid,
+            mtime: Utils.floatToDate(this.distro.mtime).toString(),
+            ctime: Utils.floatToDate(this.distro.ctime).toString(),
+            depth: this.distro.depth,
+            is_subobject: this.distro.is_subobject,
+            tree_build_time: Utils.floatToDate(
+              this.distro.tree_build_time,
+            ).toString(),
+            remote_grub_initrd: this.distro.remote_grub_initrd,
+            remote_grub_kernel: this.distro.remote_grub_kernel,
+          });
+          this.distroFormGroup.patchValue({
+            arch: this.distro.arch,
+            breed: this.distro.breed,
+            comment: this.distro.comment,
+            kernel: this.distro.kernel,
+            initrd: this.distro.initrd,
+            remote_boot_kernel: this.distro.remote_boot_kernel,
+            remote_boot_initrd: this.distro.remote_boot_initrd,
+            os_version: this.distro.os_version,
+            redhat_management_key: this.distro.redhat_management_key,
+          });
+          Utils.patchFormGroupInherited(
+            this.distroFormGroup,
+            this.distro.boot_loaders,
+            'boot_loaders',
+            ['ipxe', 'grub', 'pxe'],
           );
-          this.distroReadonlyFormGroup.controls.ctime.setValue(
-            Utils.floatToDate(this.distro.ctime).toString(),
+          Utils.patchFormGroupInherited(
+            this.distroFormGroup,
+            this.distro.owners,
+            'owners',
+            [],
           );
-          this.distroReadonlyFormGroup.controls.depth.setValue(
-            this.distro.depth,
+          Utils.patchFormGroupInherited(
+            this.distroFormGroup,
+            this.distro.autoinstall_meta,
+            'autoinstall_meta',
+            new Map(),
           );
-          this.distroFormGroup.controls.arch.setValue(this.distro.arch);
-          this.distroReadonlyFormGroup.controls.is_subobject.setValue(
-            this.distro.is_subobject,
+          Utils.patchFormGroupInherited(
+            this.distroFormGroup,
+            this.distro.fetchable_files,
+            'fetchable_files',
+            new Map(),
           );
-          this.distroReadonlyFormGroup.controls.tree_build_time.setValue(
-            Utils.floatToDate(this.distro.tree_build_time).toString(),
+          Utils.patchFormGroupInherited(
+            this.distroFormGroup,
+            this.distro.kernel_options,
+            'kernel_options',
+            new Map(),
           );
-          this.distroReadonlyFormGroup.controls.remote_grub_initrd.setValue(
-            this.distro.remote_grub_initrd,
+          Utils.patchFormGroupInherited(
+            this.distroFormGroup,
+            this.distro.kernel_options_post,
+            'kernel_options_post',
+            new Map(),
           );
-          this.distroReadonlyFormGroup.controls.remote_grub_kernel.setValue(
-            this.distro.remote_grub_kernel,
+          Utils.patchFormGroupInherited(
+            this.distroFormGroup,
+            this.distro.template_files,
+            'template_files',
+            new Map(),
           );
-
-          this.distroFormGroup.controls.breed.setValue(this.distro.breed);
-          this.distroFormGroup.controls.comment.setValue(this.distro.comment);
-          this.distroFormGroup.controls.kernel.setValue(this.distro.kernel);
-          this.distroFormGroup.controls.initrd.setValue(this.distro.initrd);
-          this.distroFormGroup.controls.remote_boot_initrd.setValue(
-            this.distro.remote_boot_initrd,
-          );
-          this.distroFormGroup.controls.remote_boot_kernel.setValue(
-            this.distro.remote_boot_kernel,
-          );
-          this.distroFormGroup.controls.os_version.setValue(
-            this.distro.os_version,
-          );
-          this.distroFormGroup.controls.redhat_management_key.setValue(
-            this.distro.redhat_management_key,
-          );
-          if (typeof this.distro.boot_loaders === 'string') {
-            this.distroFormGroup.controls.boot_loaders.setValue([
-              'ipxe',
-              'grub',
-              'pxe',
-            ]);
-            this.distroFormGroup.controls.boot_loaders_inherited.setValue(true);
-          } else {
-            this.distroFormGroup.controls.boot_loaders_inherited.setValue(
-              false,
-            );
-            this.distroFormGroup.controls.boot_loaders.setValue(
-              this.distro.boot_loaders,
-            );
-          }
-          if (typeof this.distro.owners === 'string') {
-            this.distroFormGroup.controls.owners_inherited.setValue(true);
-            this.distroFormGroup.controls.owners.setValue([]);
-          } else {
-            this.distroFormGroup.controls.owners_inherited.setValue(false);
-            this.distroFormGroup.controls.owners.setValue(this.distro.owners);
-          }
-          if (typeof this.distro.autoinstall_meta === 'string') {
-            this.distroFormGroup.controls.autoinstall_meta_inherited.setValue(
-              true,
-            );
-            this.distroFormGroup.controls.autoinstall_meta.setValue(new Map());
-          } else {
-            this.distroFormGroup.controls.autoinstall_meta_inherited.setValue(
-              false,
-            );
-            this.distroFormGroup.controls.autoinstall_meta.setValue(
-              this.distro.autoinstall_meta,
-            );
-          }
-          if (typeof this.distro.fetchable_files === 'string') {
-            this.distroFormGroup.controls.fetchable_files_inherited.setValue(
-              true,
-            );
-            this.distroFormGroup.controls.fetchable_files.setValue(new Map());
-          } else {
-            this.distroFormGroup.controls.fetchable_files_inherited.setValue(
-              false,
-            );
-            this.distroFormGroup.controls.fetchable_files.setValue(
-              this.distro.fetchable_files,
-            );
-          }
-          if (typeof this.distro.kernel_options === 'string') {
-            this.distroFormGroup.controls.kernel_options_inherited.setValue(
-              true,
-            );
-            this.distroFormGroup.controls.kernel_options.setValue(new Map());
-          } else {
-            this.distroFormGroup.controls.kernel_options_inherited.setValue(
-              false,
-            );
-            this.distroFormGroup.controls.kernel_options.setValue(
-              this.distro.kernel_options,
-            );
-          }
-          if (typeof this.distro.kernel_options_post === 'string') {
-            this.distroFormGroup.controls.kernel_options_post_inherited.setValue(
-              true,
-            );
-            this.distroFormGroup.controls.kernel_options_post.setValue(
-              new Map(),
-            );
-          } else {
-            this.distroFormGroup.controls.kernel_options_post_inherited.setValue(
-              false,
-            );
-            this.distroFormGroup.controls.kernel_options_post.setValue(
-              this.distro.kernel_options_post,
-            );
-          }
-          if (typeof this.distro.template_files === 'string') {
-            this.distroFormGroup.controls.template_files_inherited.setValue(
-              true,
-            );
-            this.distroFormGroup.controls.template_files.setValue(new Map());
-          } else {
-            this.distroFormGroup.controls.template_files_inherited.setValue(
-              false,
-            );
-            this.distroFormGroup.controls.template_files.setValue(
-              this.distro.template_files,
-            );
-          }
         },
-        (error) => {
+        error: (error) => {
           // HTML encode the error message since it originates from XML
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 
   removeDistro(): void {
     this.cobblerApiService
       .remove_distro(this.name, this.userService.token, false)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (value) => {
+      .subscribe({
+        next: (value) => {
           if (value) {
             this.router.navigate(['/items', 'distro']);
           }
@@ -349,11 +534,11 @@ export class DistroEditComponent implements OnInit, OnDestroy {
             'Close',
           );
         },
-        (error) => {
+        error: (error) => {
           // HTML encode the error message since it originates from XML
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 
   editDistro(): void {
@@ -361,31 +546,31 @@ export class DistroEditComponent implements OnInit, OnDestroy {
     this.distroFormGroup.enable();
     // Inherit inputs
     if (typeof this.distro.autoinstall_meta === 'string') {
-      this.distroFormGroup.controls.autoinstall_meta.disable();
+      this.distroFormGroup.get('autoinstall_meta').disable();
     }
     if (typeof this.distro.boot_files === 'string') {
-      this.distroFormGroup.controls.boot_files.disable();
+      this.distroFormGroup.get('boot_files').disable();
     }
     if (typeof this.distro.boot_loaders === 'string') {
-      this.distroFormGroup.controls.boot_loaders.disable();
+      this.distroFormGroup.get('boot_loaders').disable();
     }
     if (typeof this.distro.fetchable_files === 'string') {
-      this.distroFormGroup.controls.fetchable_files.disable();
+      this.distroFormGroup.get('fetchable_files').disable();
     }
     if (typeof this.distro.kernel_options === 'string') {
-      this.distroFormGroup.controls.kernel_options.disable();
+      this.distroFormGroup.get('kernel_options').disable();
     }
     if (typeof this.distro.kernel_options_post === 'string') {
-      this.distroFormGroup.controls.kernel_options_post.disable();
+      this.distroFormGroup.get('kernel_options_post').disable();
     }
     if (typeof this.distro.mgmt_classes === 'string') {
-      this.distroFormGroup.controls.mgmt_classes.disable();
+      this.distroFormGroup.get('mgmt_classes').disable();
     }
     if (typeof this.distro.owners === 'string') {
-      this.distroFormGroup.controls.owners.disable();
+      this.distroFormGroup.get('owners').disable();
     }
     if (typeof this.distro.template_files === 'string') {
-      this.distroFormGroup.controls.template_files.disable();
+      this.distroFormGroup.get('template_files').disable();
     }
   }
 
@@ -411,7 +596,7 @@ export class DistroEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_distro_as_rendered(this.distro.name, this.userService.token)
       .subscribe((value) => {
-        const dialogRef = this.dialog.open(DialogBoxItemRenderedComponent, {
+        this.dialog.open(DialogBoxItemRenderedComponent, {
           data: {
             itemType: 'Distro',
             uid: this.distro.uid,
@@ -439,26 +624,26 @@ export class DistroEditComponent implements OnInit, OnDestroy {
       this.cobblerApiService
         .get_distro_handle(name, this.userService.token)
         .pipe(takeUntil(this.ngUnsubscribe))
-        .subscribe(
-          (distroHandle) => {
+        .subscribe({
+          next: (distroHandle) => {
             this.cobblerApiService
               .copy_distro(distroHandle, newItemName, this.userService.token)
               .pipe(takeUntil(this.ngUnsubscribe))
-              .subscribe(
-                (value) => {
+              .subscribe({
+                next: () => {
                   this.router.navigate(['/items', 'distro', newItemName]);
                 },
-                (error) => {
+                error: (error) => {
                   // HTML encode the error message since it originates from XML
                   this._snackBar.open(Utils.toHTML(error.message), 'Close');
                 },
-              );
+              });
           },
-          (error) => {
+          error: (error) => {
             // HTML encode the error message since it originates from XML
             this._snackBar.open(Utils.toHTML(error.message), 'Close');
           },
-        );
+        });
     });
   }
 
@@ -470,8 +655,8 @@ export class DistroEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_distro_handle(this.name, this.userService.token)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (distroHandle) => {
+      .subscribe({
+        next: (distroHandle) => {
           let modifyObservables: Observable<boolean>[] = [];
           dirtyValues.forEach((value, key) => {
             modifyObservables.push(
@@ -483,29 +668,29 @@ export class DistroEditComponent implements OnInit, OnDestroy {
               ),
             );
           });
-          combineLatest(modifyObservables).subscribe(
-            (value) => {
+          combineLatest(modifyObservables).subscribe({
+            next: () => {
               this.cobblerApiService
                 .save_distro(distroHandle, this.userService.token)
-                .subscribe(
-                  (value1) => {
+                .subscribe({
+                  next: () => {
                     this.isEditMode = false;
                     this.distroFormGroup.disable();
                     this.refreshData();
                   },
-                  (error) => {
+                  error: (error) => {
                     this._snackBar.open(Utils.toHTML(error.message), 'Close');
                   },
-                );
+                });
             },
-            (error) => {
+            error: (error) => {
               this._snackBar.open(Utils.toHTML(error.message), 'Close');
             },
-          );
+          });
         },
-        (error) => {
+        error: (error) => {
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 }

--- a/projects/cobbler-frontend/src/app/items/file/edit/file-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/file/edit/file-edit.component.html
@@ -66,64 +66,112 @@
 </div>
 
 <form class="form-replicate" [formGroup]="fileReadonlyFormGroup">
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Name</mat-label>
-    <input matInput type="text" formControlName="name" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>UID</mat-label>
-    <input matInput type="text" formControlName="uid" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Last modified time</mat-label>
-    <input matInput type="text" formControlName="mtime" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Creation time</mat-label>
-    <input matInput type="text" formControlName="ctime" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Depth</mat-label>
-    <input matInput type="number" formControlName="depth" />
-  </mat-form-field>
-  <mat-checkbox class="form-field-full-width" formControlName="is_subobject">
-    Is Subobject?
-  </mat-checkbox>
+  @for (input of fileReadonlyInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+    }
+  }
 </form>
 
 <form class="form-replicate" [formGroup]="fileFormGroup">
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Comment</mat-label>
-    <input matInput type="text" formControlName="comment" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Action</mat-label>
-    <input matInput type="text" formControlName="action" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Group</mat-label>
-    <input matInput type="text" formControlName="group" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Mode</mat-label>
-    <input matInput type="text" formControlName="mode" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Owner</mat-label>
-    <input matInput type="text" formControlName="owner" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Path</mat-label>
-    <input matInput type="text" formControlName="path" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Template</mat-label>
-    <input matInput type="text" formControlName="template" />
-  </mat-form-field>
-  <mat-checkbox class="form-field-full-width" formControlName="is_dir"
-    >Is Directory?</mat-checkbox
-  >
+  @for (input of fileEditableInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+      @case (CobblerInputChoices.MULTI_SELECT) {
+        <ng-container class="form-field-full-width">
+          <cobbler-multi-select
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-multi-select>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+      @case (CobblerInputChoices.KEY_VALUE) {
+        <ng-container class="form-field-full-width">
+          <cobbler-key-value-editor
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-key-value-editor>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+    }
+  }
   @if (isEditMode) {
-    <button mat-button (click)="saveFile()">Save Distro</button>
+    <div>
+      <button mat-button (click)="saveFile()">Save File</button>
+    </div>
   }
 </form>

--- a/projects/cobbler-frontend/src/app/items/file/edit/file-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/file/edit/file-edit.component.ts
@@ -24,6 +24,10 @@ import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
 import { KeyValueEditorComponent } from '../../../common/key-value-editor/key-value-editor.component';
 import { MultiSelectComponent } from '../../../common/multi-select/multi-select.component';
+import {
+  cobblerItemEditableData,
+  cobblerItemReadonlyData,
+} from '../../metadata';
 
 @Component({
   selector: 'cobbler-edit',
@@ -53,79 +57,16 @@ export class FileEditComponent implements OnInit, OnDestroy {
   private ngUnsubscribe = new Subject<void>();
 
   // Form data
-  fileReadonlyInputData: Array<CobblerInputData> = [
-    {
-      formControlName: 'name',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Name',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'uid',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'UID',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'mtime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Last modified time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'ctime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Creation time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'depth',
-      inputType: CobblerInputChoices.NUMBER,
-      label: 'Depth',
-      disabled: false,
-      readonly: true,
-      defaultValue: 0,
-      inherited: false,
-    },
-    {
-      formControlName: 'is_subobject',
-      inputType: CobblerInputChoices.CHECKBOX,
-      label: 'Is Subobject?',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-  ];
+  fileReadonlyInputData = cobblerItemReadonlyData;
   fileEditableInputData: Array<CobblerInputData> = [
+    ...cobblerItemEditableData,
     {
       formControlName: 'is_dir',
       inputType: CobblerInputChoices.CHECKBOX,
-      label: 'Is Subobject?',
+      label: 'Is Directory?',
       disabled: true,
       readonly: false,
       defaultValue: false,
-      inherited: false,
-    },
-    {
-      formControlName: 'comment',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Comment',
-      disabled: true,
-      readonly: false,
-      defaultValue: '',
       inherited: false,
     },
     {

--- a/projects/cobbler-frontend/src/app/items/file/edit/file-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/file/edit/file-edit.component.ts
@@ -1,10 +1,5 @@
 import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
-import {
-  FormBuilder,
-  FormControl,
-  FormsModule,
-  ReactiveFormsModule,
-} from '@angular/forms';
+import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
@@ -142,42 +137,12 @@ export class FileEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
-    this.fileReadonlyInputData.forEach((value) => {
-      this.fileReadonlyFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.fileReadonlyFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
-    this.fileEditableInputData.forEach((value) => {
-      this.fileFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.fileFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
+    Utils.fillupItemFormGroup(
+      this.fileReadonlyFormGroup,
+      this.fileFormGroup,
+      this.fileReadonlyInputData,
+      this.fileEditableInputData,
+    );
   }
 
   ngOnInit(): void {

--- a/projects/cobbler-frontend/src/app/items/file/edit/file-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/file/edit/file-edit.component.ts
@@ -5,14 +5,12 @@ import {
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
-import { MatOption } from '@angular/material/autocomplete';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
-import { MatSelect } from '@angular/material/select';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltip } from '@angular/material/tooltip';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -22,8 +20,10 @@ import { takeUntil } from 'rxjs/operators';
 import { DialogBoxConfirmCancelEditComponent } from '../../../common/dialog-box-confirm-cancel-edit/dialog-box-confirm-cancel-edit.component';
 import { DialogItemCopyComponent } from '../../../common/dialog-item-copy/dialog-item-copy.component';
 import { UserService } from '../../../services/user.service';
-import Utils from '../../../utils';
+import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
+import { KeyValueEditorComponent } from '../../../common/key-value-editor/key-value-editor.component';
+import { MultiSelectComponent } from '../../../common/multi-select/multi-select.component';
 
 @Component({
   selector: 'cobbler-edit',
@@ -37,41 +37,159 @@ import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-
     MatIconButton,
     MatInput,
     MatLabel,
-    MatOption,
-    MatSelect,
     MatTooltip,
     ReactiveFormsModule,
+    KeyValueEditorComponent,
+    MultiSelectComponent,
   ],
   templateUrl: './file-edit.component.html',
   styleUrl: './file-edit.component.scss',
 })
 export class FileEditComponent implements OnInit, OnDestroy {
+  // Bring Enum to HTML scope
+  protected readonly CobblerInputChoices = CobblerInputChoices;
+
   // Unsubscribe
   private ngUnsubscribe = new Subject<void>();
+
+  // Form data
+  fileReadonlyInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'name',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Name',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'uid',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'UID',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'mtime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Last modified time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'ctime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Creation time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'depth',
+      inputType: CobblerInputChoices.NUMBER,
+      label: 'Depth',
+      disabled: false,
+      readonly: true,
+      defaultValue: 0,
+      inherited: false,
+    },
+    {
+      formControlName: 'is_subobject',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Is Subobject?',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+  ];
+  fileEditableInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'is_dir',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Is Subobject?',
+      disabled: true,
+      readonly: false,
+      defaultValue: false,
+      inherited: false,
+    },
+    {
+      formControlName: 'comment',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Comment',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'action',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Action',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'group',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Group',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'mode',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Mode',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'owner',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Owner',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'path',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Path',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'template',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Template',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+  ];
 
   // Form
   name: string;
   file: File;
   private readonly _formBuilder = inject(FormBuilder);
-  fileReadonlyFormGroup = this._formBuilder.group({
-    name: new FormControl({ value: '', disabled: false }),
-    uid: new FormControl({ value: '', disabled: false }),
-    mtime: new FormControl({ value: '', disabled: false }),
-    ctime: new FormControl({ value: '', disabled: false }),
-    depth: new FormControl({ value: 0, disabled: false }),
-    is_subobject: new FormControl({ value: false, disabled: false }),
-  });
-  fileFormGroup = this._formBuilder.group({
-    is_dir: new FormControl({ value: false, disabled: true }),
-    comment: new FormControl({ value: '', disabled: true }),
-    redhat_management_key: new FormControl({ value: '', disabled: true }),
-    action: new FormControl({ value: '', disabled: true }),
-    group: new FormControl({ value: '', disabled: true }),
-    mode: new FormControl({ value: '', disabled: true }),
-    owner: new FormControl({ value: '', disabled: true }),
-    path: new FormControl({ value: '', disabled: true }),
-    template: new FormControl({ value: '', disabled: true }),
-  });
+  fileReadonlyFormGroup = this._formBuilder.group({});
+  fileFormGroup = this._formBuilder.group({});
   isEditMode: boolean = false;
 
   constructor(
@@ -83,6 +201,42 @@ export class FileEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
+    this.fileReadonlyInputData.forEach((value) => {
+      this.fileReadonlyFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.fileReadonlyFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
+    this.fileEditableInputData.forEach((value) => {
+      this.fileFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.fileFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
   }
 
   ngOnInit(): void {
@@ -98,42 +252,40 @@ export class FileEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_file(this.name, false, false, this.userService.token)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (value) => {
+      .subscribe({
+        next: (value) => {
           this.file = value;
-          this.fileReadonlyFormGroup.controls.name.setValue(this.file.name);
-          this.fileReadonlyFormGroup.controls.uid.setValue(this.file.uid);
-          this.fileReadonlyFormGroup.controls.mtime.setValue(
-            new Date(this.file.mtime * 1000).toString(),
-          );
-          this.fileReadonlyFormGroup.controls.ctime.setValue(
-            new Date(this.file.ctime * 1000).toString(),
-          );
-          this.fileReadonlyFormGroup.controls.depth.setValue(this.file.depth);
-          this.fileReadonlyFormGroup.controls.is_subobject.setValue(
-            this.file.is_subobject,
-          );
-          this.fileFormGroup.controls.comment.setValue(this.file.comment);
-          this.fileFormGroup.controls.action.setValue(this.file.action);
-          this.fileFormGroup.controls.group.setValue(this.file.group);
-          this.fileFormGroup.controls.mode.setValue(this.file.mode);
-          this.fileFormGroup.controls.owner.setValue(this.file.owner);
-          this.fileFormGroup.controls.path.setValue(this.file.path);
-          this.fileFormGroup.controls.template.setValue(this.file.template);
+          this.fileReadonlyFormGroup.patchValue({
+            name: this.file.name,
+            uid: this.file.uid,
+            mtime: Utils.floatToDate(this.file.mtime).toString(),
+            ctime: Utils.floatToDate(this.file.ctime).toString(),
+            depth: this.file.depth,
+            is_subobject: this.file.is_subobject,
+          });
+          this.fileFormGroup.patchValue({
+            comment: this.file.comment,
+            action: this.file.action,
+            group: this.file.group,
+            mode: this.file.mode,
+            owner: this.file.owner,
+            path: this.file.path,
+            template: this.file.template,
+          });
         },
-        (error) => {
+        error: (error) => {
           // HTML encode the error message since it originates from XML
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 
   removeFile(): void {
     this.cobblerApiService
       .remove_file(this.name, this.userService.token, false)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (value) => {
+      .subscribe({
+        next: (value) => {
           if (value) {
             this.router.navigate(['/items', 'file']);
           }
@@ -143,11 +295,11 @@ export class FileEditComponent implements OnInit, OnDestroy {
             'Close',
           );
         },
-        (error) => {
+        error: (error) => {
           // HTML encode the error message since it originates from XML
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 
   editFile(): void {
@@ -177,7 +329,7 @@ export class FileEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_file_as_rendered(this.file.name, this.userService.token)
       .subscribe((value) => {
-        const dialogRef = this.dialog.open(DialogBoxItemRenderedComponent, {
+        this.dialog.open(DialogBoxItemRenderedComponent, {
           data: {
             itemType: 'File',
             uid: this.file.uid,
@@ -205,26 +357,26 @@ export class FileEditComponent implements OnInit, OnDestroy {
       this.cobblerApiService
         .get_file_handle(name, this.userService.token)
         .pipe(takeUntil(this.ngUnsubscribe))
-        .subscribe(
-          (fileHandle) => {
+        .subscribe({
+          next: (fileHandle) => {
             this.cobblerApiService
               .copy_file(fileHandle, newItemName, this.userService.token)
               .pipe(takeUntil(this.ngUnsubscribe))
-              .subscribe(
-                (value) => {
+              .subscribe({
+                next: () => {
                   this.router.navigate(['/items', 'file', newItemName]);
                 },
-                (error) => {
+                error: (error) => {
                   // HTML encode the error message since it originates from XML
                   this._snackBar.open(Utils.toHTML(error.message), 'Close');
                 },
-              );
+              });
           },
-          (error) => {
+          error: (error) => {
             // HTML encode the error message since it originates from XML
             this._snackBar.open(Utils.toHTML(error.message), 'Close');
           },
-        );
+        });
     });
   }
 
@@ -236,8 +388,8 @@ export class FileEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_file_handle(this.name, this.userService.token)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (fileHandle) => {
+      .subscribe({
+        next: (fileHandle) => {
           let modifyObservables: Observable<boolean>[] = [];
           dirtyValues.forEach((value, key) => {
             modifyObservables.push(
@@ -249,29 +401,29 @@ export class FileEditComponent implements OnInit, OnDestroy {
               ),
             );
           });
-          combineLatest(modifyObservables).subscribe(
-            (value) => {
+          combineLatest(modifyObservables).subscribe({
+            next: () => {
               this.cobblerApiService
                 .save_file(fileHandle, this.userService.token)
-                .subscribe(
-                  (value1) => {
+                .subscribe({
+                  next: () => {
                     this.isEditMode = false;
                     this.fileFormGroup.disable();
                     this.refreshData();
                   },
-                  (error) => {
+                  error: (error) => {
                     this._snackBar.open(Utils.toHTML(error.message), 'Close');
                   },
-                );
+                });
             },
-            (error) => {
+            error: (error) => {
               this._snackBar.open(Utils.toHTML(error.message), 'Close');
             },
-          );
+          });
         },
-        (error) => {
+        error: (error) => {
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 }

--- a/projects/cobbler-frontend/src/app/items/image/edit/image-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/image/edit/image-edit.component.html
@@ -66,85 +66,112 @@
 </div>
 
 <form class="form-replicate" [formGroup]="imageReadonlyFormGroup">
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Name</mat-label>
-    <input matInput type="text" formControlName="name" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>UID</mat-label>
-    <input matInput type="text" formControlName="uid" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Last modified time</mat-label>
-    <input matInput type="text" formControlName="mtime" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Creation time</mat-label>
-    <input matInput type="text" formControlName="ctime" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Depth</mat-label>
-    <input matInput type="number" formControlName="depth" />
-  </mat-form-field>
-  <mat-checkbox class="form-field-full-width" formControlName="is_subobject"
-    >Is Subobject?</mat-checkbox
-  >
+  @for (input of imageReadonlyInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+    }
+  }
 </form>
 
 <form class="form-replicate" [formGroup]="imageFormGroup">
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Boot Loaders"
-      formControlName="boot_loaders"
-    ></cobbler-multi-select>
-    <mat-checkbox formControlName="boot_loaders_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Comment</mat-label>
-    <input matInput type="text" formControlName="comment" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Network Count</mat-label>
-    <input matInput type="number" formControlName="network_count" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Parent</mat-label>
-    <input matInput type="text" formControlName="parent" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Arch</mat-label>
-    <input matInput type="text" formControlName="arch" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Autoinstall</mat-label>
-    <input matInput type="text" formControlName="autoinstall" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Operating System Breed</mat-label>
-    <input matInput type="text" formControlName="breed" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Image File</mat-label>
-    <input matInput type="text" formControlName="file" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Image Type</mat-label>
-    <input matInput type="text" formControlName="image_type" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Operating System Version</mat-label>
-    <input matInput type="text" formControlName="os_version" />
-  </mat-form-field>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Owners"
-      formControlName="owners"
-    ></cobbler-multi-select>
-    <mat-checkbox formControlName="owners_inherited">Inherited</mat-checkbox>
-  </ng-container>
+  @for (input of imageEditableInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+      @case (CobblerInputChoices.MULTI_SELECT) {
+        <ng-container class="form-field-full-width">
+          <cobbler-multi-select
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-multi-select>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+      @case (CobblerInputChoices.KEY_VALUE) {
+        <ng-container class="form-field-full-width">
+          <cobbler-key-value-editor
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-key-value-editor>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+    }
+  }
   @if (isEditMode) {
-    <button mat-button (click)="saveImage()">Save Distro</button>
+    <div>
+      <button mat-button (click)="saveImage()">Save Image</button>
+    </div>
   }
 </form>

--- a/projects/cobbler-frontend/src/app/items/image/edit/image-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/image/edit/image-edit.component.ts
@@ -25,6 +25,10 @@ import { UserService } from '../../../services/user.service';
 import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
 import { KeyValueEditorComponent } from '../../../common/key-value-editor/key-value-editor.component';
+import {
+  cobblerItemEditableData,
+  cobblerItemReadonlyData,
+} from '../../metadata';
 
 @Component({
   selector: 'cobbler-image-edit',
@@ -54,63 +58,9 @@ export class ImageEditComponent implements OnInit, OnDestroy {
   private ngUnsubscribe = new Subject<void>();
 
   // Form data
-  imageReadonlyInputData: Array<CobblerInputData> = [
-    {
-      formControlName: 'name',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Name',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'uid',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'UID',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'mtime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Last modified time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'ctime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Creation time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'depth',
-      inputType: CobblerInputChoices.NUMBER,
-      label: 'Depth',
-      disabled: false,
-      readonly: true,
-      defaultValue: 0,
-      inherited: false,
-    },
-    {
-      formControlName: 'is_subobject',
-      inputType: CobblerInputChoices.CHECKBOX,
-      label: 'Is Subobject?',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-  ];
+  imageReadonlyInputData = cobblerItemReadonlyData;
   imageEditableInputData: Array<CobblerInputData> = [
+    ...cobblerItemEditableData,
     {
       formControlName: 'network_count',
       inputType: CobblerInputChoices.NUMBER,
@@ -118,15 +68,6 @@ export class ImageEditComponent implements OnInit, OnDestroy {
       disabled: true,
       readonly: false,
       defaultValue: 0,
-      inherited: false,
-    },
-    {
-      formControlName: 'comment',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Comment',
-      disabled: true,
-      readonly: false,
-      defaultValue: '',
       inherited: false,
     },
     {

--- a/projects/cobbler-frontend/src/app/items/image/edit/image-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/image/edit/image-edit.component.ts
@@ -2,7 +2,6 @@ import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
   AbstractControl,
   FormBuilder,
-  FormControl,
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
@@ -179,42 +178,12 @@ export class ImageEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
-    this.imageReadonlyInputData.forEach((value) => {
-      this.imageReadonlyFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.imageReadonlyFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
-    this.imageEditableInputData.forEach((value) => {
-      this.imageFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.imageFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
+    Utils.fillupItemFormGroup(
+      this.imageReadonlyFormGroup,
+      this.imageFormGroup,
+      this.imageReadonlyInputData,
+      this.imageEditableInputData,
+    );
   }
 
   ngOnInit(): void {

--- a/projects/cobbler-frontend/src/app/items/image/edit/image-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/image/edit/image-edit.component.ts
@@ -1,18 +1,17 @@
 import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
+  AbstractControl,
   FormBuilder,
   FormControl,
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
-import { MatOption } from '@angular/material/autocomplete';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
-import { MatSelect } from '@angular/material/select';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltip } from '@angular/material/tooltip';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -23,8 +22,9 @@ import { DialogBoxConfirmCancelEditComponent } from '../../../common/dialog-box-
 import { DialogItemCopyComponent } from '../../../common/dialog-item-copy/dialog-item-copy.component';
 import { MultiSelectComponent } from '../../../common/multi-select/multi-select.component';
 import { UserService } from '../../../services/user.service';
-import Utils from '../../../utils';
+import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
+import { KeyValueEditorComponent } from '../../../common/key-value-editor/key-value-editor.component';
 
 @Component({
   selector: 'cobbler-image-edit',
@@ -38,47 +38,195 @@ import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-
     MatIconButton,
     MatInput,
     MatLabel,
-    MatOption,
-    MatSelect,
     MatTooltip,
     ReactiveFormsModule,
     MultiSelectComponent,
+    KeyValueEditorComponent,
   ],
   templateUrl: './image-edit.component.html',
   styleUrl: './image-edit.component.scss',
 })
 export class ImageEditComponent implements OnInit, OnDestroy {
+  // Bring Enum to HTML scope
+  protected readonly CobblerInputChoices = CobblerInputChoices;
+
   // Unsubscribe
   private ngUnsubscribe = new Subject<void>();
+
+  // Form data
+  imageReadonlyInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'name',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Name',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'uid',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'UID',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'mtime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Last modified time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'ctime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Creation time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'depth',
+      inputType: CobblerInputChoices.NUMBER,
+      label: 'Depth',
+      disabled: false,
+      readonly: true,
+      defaultValue: 0,
+      inherited: false,
+    },
+    {
+      formControlName: 'is_subobject',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Is Subobject?',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+  ];
+  imageEditableInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'network_count',
+      inputType: CobblerInputChoices.NUMBER,
+      label: 'Network Count',
+      disabled: true,
+      readonly: false,
+      defaultValue: 0,
+      inherited: false,
+    },
+    {
+      formControlName: 'comment',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Comment',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'redhat_management_key',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'RedHat Management Key',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'parent',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Parent',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'arch',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Arch',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'autoinstall',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Autoinstall',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'breed',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Operating System Breed',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'file',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Image File',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'image_type',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Image Type',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'os_version',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Operating System Version',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'boot_loaders',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Boot Loaders',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+    {
+      formControlName: 'owners',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Owners',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+  ];
 
   // Form
   name: string;
   image: Image;
   private readonly _formBuilder = inject(FormBuilder);
-  imageReadonlyFormGroup = this._formBuilder.group({
-    name: new FormControl({ value: '', disabled: false }),
-    uid: new FormControl({ value: '', disabled: false }),
-    mtime: new FormControl({ value: '', disabled: false }),
-    ctime: new FormControl({ value: '', disabled: false }),
-    depth: new FormControl({ value: 0, disabled: false }),
-    is_subobject: new FormControl({ value: false, disabled: false }),
-  });
-  imageFormGroup = this._formBuilder.group({
-    network_count: new FormControl({ value: 0, disabled: true }),
-    comment: new FormControl({ value: '', disabled: true }),
-    redhat_management_key: new FormControl({ value: '', disabled: true }),
-    parent: new FormControl({ value: '', disabled: true }),
-    arch: new FormControl({ value: '', disabled: true }),
-    autoinstall: new FormControl({ value: '', disabled: true }),
-    breed: new FormControl({ value: '', disabled: true }),
-    file: new FormControl({ value: '', disabled: true }),
-    image_type: new FormControl({ value: '', disabled: true }),
-    os_version: new FormControl({ value: '', disabled: true }),
-    boot_loaders: new FormControl({ value: [], disabled: true }),
-    boot_loaders_inherited: new FormControl({ value: false, disabled: true }),
-    owners: new FormControl({ value: [], disabled: true }),
-    owners_inherited: new FormControl({ value: false, disabled: true }),
-  });
+  imageReadonlyFormGroup = this._formBuilder.group({});
+  imageFormGroup = this._formBuilder.group({});
   isEditMode: boolean = false;
 
   constructor(
@@ -90,17 +238,57 @@ export class ImageEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
+    this.imageReadonlyInputData.forEach((value) => {
+      this.imageReadonlyFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.imageReadonlyFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
+    this.imageEditableInputData.forEach((value) => {
+      this.imageFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.imageFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
   }
 
   ngOnInit(): void {
     this.refreshData();
     // Observables for inherited properties
-    this.imageFormGroup.controls.boot_loaders_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.imageFormGroup.controls.boot_loaders),
-    );
-    this.imageFormGroup.controls.owners_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.imageFormGroup.controls.owners),
-    );
+    this.imageFormGroup
+      .get('boot_loaders_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.imageFormGroup.get('boot_loaders')),
+      );
+    this.imageFormGroup
+      .get('owners_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.imageFormGroup.get('owners')),
+      );
   }
 
   ngOnDestroy(): void {
@@ -108,7 +296,9 @@ export class ImageEditComponent implements OnInit, OnDestroy {
     this.ngUnsubscribe.complete();
   }
 
-  getInheritObservable(valueControl: FormControl): (value: boolean) => void {
+  getInheritObservable(
+    valueControl: AbstractControl,
+  ): (value: boolean) => void {
     return (value: boolean): void => {
       if (!this.isEditMode) {
         // If we are not in edit-mode we want to discard processing the event
@@ -126,72 +316,54 @@ export class ImageEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_image(this.name, false, false, this.userService.token)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (value) => {
+      .subscribe({
+        next: (value) => {
           this.image = value;
-          this.imageReadonlyFormGroup.controls.name.setValue(this.image.name);
-          this.imageReadonlyFormGroup.controls.uid.setValue(this.image.uid);
-          this.imageReadonlyFormGroup.controls.mtime.setValue(
-            new Date(this.image.mtime * 1000).toString(),
+          this.imageReadonlyFormGroup.patchValue({
+            name: this.image.name,
+            uid: this.image.uid,
+            mtime: Utils.floatToDate(this.image.mtime).toString(),
+            ctime: Utils.floatToDate(this.image.ctime).toString(),
+            depth: this.image.depth,
+            is_subobject: this.image.is_subobject,
+          });
+          this.imageFormGroup.patchValue({
+            network_count: this.image.network_count,
+            comment: this.image.comment,
+            parent: this.image.parent,
+            arch: this.image.arch,
+            autoinstall: this.image.autoinstall,
+            breed: this.image.breed,
+            file: this.image.file,
+            image_type: this.image.image_type,
+            os_version: this.image.os_version,
+          });
+          Utils.patchFormGroupInherited(
+            this.imageFormGroup,
+            this.image.boot_loaders,
+            'boot_loaders',
+            ['ipxe', 'grub', 'pxe'],
           );
-          this.imageReadonlyFormGroup.controls.ctime.setValue(
-            new Date(this.image.ctime * 1000).toString(),
+          Utils.patchFormGroupInherited(
+            this.imageFormGroup,
+            this.image.owners,
+            'owners',
+            [],
           );
-          this.imageReadonlyFormGroup.controls.depth.setValue(this.image.depth);
-          this.imageReadonlyFormGroup.controls.is_subobject.setValue(
-            this.image.is_subobject,
-          );
-          this.imageFormGroup.controls.network_count.setValue(
-            this.image.network_count,
-          );
-          this.imageFormGroup.controls.comment.setValue(this.image.comment);
-          this.imageFormGroup.controls.parent.setValue(this.image.parent);
-          this.imageFormGroup.controls.arch.setValue(this.image.arch);
-          this.imageFormGroup.controls.autoinstall.setValue(
-            this.image.autoinstall,
-          );
-          this.imageFormGroup.controls.breed.setValue(this.image.breed);
-          this.imageFormGroup.controls.file.setValue(this.image.file);
-          this.imageFormGroup.controls.image_type.setValue(
-            this.image.image_type,
-          );
-          this.imageFormGroup.controls.os_version.setValue(
-            this.image.os_version,
-          );
-          if (typeof this.image.boot_loaders === 'string') {
-            this.imageFormGroup.controls.boot_loaders_inherited.setValue(true);
-            this.imageFormGroup.controls.boot_loaders.setValue([
-              'ipxe',
-              'grub',
-              'pxe',
-            ]);
-          } else {
-            this.imageFormGroup.controls.boot_loaders_inherited.setValue(false);
-            this.imageFormGroup.controls.boot_loaders.setValue(
-              this.image.boot_loaders,
-            );
-          }
-          if (typeof this.image.owners === 'string') {
-            this.imageFormGroup.controls.owners_inherited.setValue(true);
-            this.imageFormGroup.controls.owners.setValue([]);
-          } else {
-            this.imageFormGroup.controls.owners_inherited.setValue(false);
-            this.imageFormGroup.controls.owners.setValue(this.image.owners);
-          }
         },
-        (error) => {
+        error: (error) => {
           // HTML encode the error message since it originates from XML
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 
   removeImage(): void {
     this.cobblerApiService
       .remove_image(this.name, this.userService.token, false)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (value) => {
+      .subscribe({
+        next: (value) => {
           if (value) {
             this.router.navigate(['/items', 'image']);
           }
@@ -201,11 +373,11 @@ export class ImageEditComponent implements OnInit, OnDestroy {
             'Close',
           );
         },
-        (error) => {
+        error: (error) => {
           // HTML encode the error message since it originates from XML
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 
   editImage(): void {
@@ -213,10 +385,10 @@ export class ImageEditComponent implements OnInit, OnDestroy {
     this.imageFormGroup.enable();
     // Inherit inputs
     if (typeof this.image.boot_loaders === 'string') {
-      this.imageFormGroup.controls.boot_loaders.disable();
+      this.imageFormGroup.get('boot_loaders').disable();
     }
     if (typeof this.image.owners === 'string') {
-      this.imageFormGroup.controls.owners.disable();
+      this.imageFormGroup.get('owners').disable();
     }
   }
 
@@ -242,7 +414,7 @@ export class ImageEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_image_as_rendered(this.image.name, this.userService.token)
       .subscribe((value) => {
-        const dialogRef = this.dialog.open(DialogBoxItemRenderedComponent, {
+        this.dialog.open(DialogBoxItemRenderedComponent, {
           data: {
             itemType: 'Image',
             uid: this.image.uid,
@@ -270,26 +442,26 @@ export class ImageEditComponent implements OnInit, OnDestroy {
       this.cobblerApiService
         .get_image_handle(name, this.userService.token)
         .pipe(takeUntil(this.ngUnsubscribe))
-        .subscribe(
-          (imageHandle) => {
+        .subscribe({
+          next: (imageHandle) => {
             this.cobblerApiService
               .copy_image(imageHandle, newItemName, this.userService.token)
               .pipe(takeUntil(this.ngUnsubscribe))
-              .subscribe(
-                (value) => {
+              .subscribe({
+                next: () => {
                   this.router.navigate(['/items', 'image', newItemName]);
                 },
-                (error) => {
+                error: (error) => {
                   // HTML encode the error message since it originates from XML
                   this._snackBar.open(Utils.toHTML(error.message), 'Close');
                 },
-              );
+              });
           },
-          (error) => {
+          error: (error) => {
             // HTML encode the error message since it originates from XML
             this._snackBar.open(Utils.toHTML(error.message), 'Close');
           },
-        );
+        });
     });
   }
 
@@ -301,8 +473,8 @@ export class ImageEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_image_handle(this.name, this.userService.token)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (imageHandle) => {
+      .subscribe({
+        next: (imageHandle) => {
           let modifyObservables: Observable<boolean>[] = [];
           dirtyValues.forEach((value, key) => {
             modifyObservables.push(
@@ -314,29 +486,29 @@ export class ImageEditComponent implements OnInit, OnDestroy {
               ),
             );
           });
-          combineLatest(modifyObservables).subscribe(
-            (value) => {
+          combineLatest(modifyObservables).subscribe({
+            next: () => {
               this.cobblerApiService
                 .save_image(imageHandle, this.userService.token)
-                .subscribe(
-                  (value1) => {
+                .subscribe({
+                  next: () => {
                     this.isEditMode = false;
                     this.imageFormGroup.disable();
                     this.refreshData();
                   },
-                  (error) => {
+                  error: (error) => {
                     this._snackBar.open(Utils.toHTML(error.message), 'Close');
                   },
-                );
+                });
             },
-            (error) => {
+            error: (error) => {
               this._snackBar.open(Utils.toHTML(error.message), 'Close');
             },
-          );
+          });
         },
-        (error) => {
+        error: (error) => {
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 }

--- a/projects/cobbler-frontend/src/app/items/management-class/edit/management-class-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/management-class/edit/management-class-edit.component.html
@@ -71,69 +71,112 @@
 </div>
 
 <form class="form-replicate" [formGroup]="managementClassReadonlyFormGroup">
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Name</mat-label>
-    <input matInput type="text" formControlName="name" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>UID</mat-label>
-    <input matInput type="text" formControlName="uid" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Last modified time</mat-label>
-    <input matInput type="text" formControlName="mtime" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Creation time</mat-label>
-    <input matInput type="text" formControlName="ctime" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Depth</mat-label>
-    <input matInput type="number" formControlName="depth" />
-  </mat-form-field>
-  <mat-checkbox class="form-field-full-width" formControlName="is_subobject"
-    >Is Subobject?</mat-checkbox
-  >
+  @for (input of managementClassReadonlyInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+    }
+  }
 </form>
 
 <form class="form-replicate" [formGroup]="managementClassFormGroup">
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Comment</mat-label>
-    <input matInput type="text" formControlName="comment" />
-  </mat-form-field>
-  <mat-checkbox class="form-field-full-width" formControlName="is_definition"
-    >Is Definition?</mat-checkbox
-  >
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Class Name</mat-label>
-    <input matInput type="text" formControlName="class_name" />
-  </mat-form-field>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Files"
-      formControlName="files"
-    ></cobbler-multi-select>
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Owners"
-      formControlName="owners"
-    ></cobbler-multi-select>
-    <mat-checkbox formControlName="owners_inherited">Inherited</mat-checkbox>
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Packages"
-      formControlName="packages"
-    ></cobbler-multi-select>
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Params"
-      formControlName="params"
-    ></cobbler-key-value-editor>
-  </ng-container>
+  @for (input of managementClassEditableInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+      @case (CobblerInputChoices.MULTI_SELECT) {
+        <ng-container class="form-field-full-width">
+          <cobbler-multi-select
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-multi-select>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+      @case (CobblerInputChoices.KEY_VALUE) {
+        <ng-container class="form-field-full-width">
+          <cobbler-key-value-editor
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-key-value-editor>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+    }
+  }
   @if (isEditMode) {
-    <button mat-button (click)="saveProfile()">Save Distro</button>
+    <div>
+      <button mat-button (click)="saveProfile()">Save Management Class</button>
+    </div>
   }
 </form>

--- a/projects/cobbler-frontend/src/app/items/management-class/edit/management-class-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/management-class/edit/management-class-edit.component.ts
@@ -1,18 +1,17 @@
 import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
+  AbstractControl,
   FormBuilder,
   FormControl,
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
-import { MatOption } from '@angular/material/autocomplete';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
-import { MatSelect } from '@angular/material/select';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltip } from '@angular/material/tooltip';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -24,7 +23,7 @@ import { DialogItemCopyComponent } from '../../../common/dialog-item-copy/dialog
 import { KeyValueEditorComponent } from '../../../common/key-value-editor/key-value-editor.component';
 import { MultiSelectComponent } from '../../../common/multi-select/multi-select.component';
 import { UserService } from '../../../services/user.service';
-import Utils from '../../../utils';
+import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
 
 @Component({
@@ -39,8 +38,6 @@ import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-
     MatIconButton,
     MatInput,
     MatLabel,
-    MatOption,
-    MatSelect,
     MatTooltip,
     ReactiveFormsModule,
     MultiSelectComponent,
@@ -50,32 +47,150 @@ import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-
   styleUrl: './management-class-edit.component.scss',
 })
 export class ManagementClassEditComponent implements OnInit, OnDestroy {
+  // Bring Enum to HTML scope
+  protected readonly CobblerInputChoices = CobblerInputChoices;
+
   // Unsubscribe
   private ngUnsubscribe = new Subject<void>();
+
+  // Form data
+  managementClassReadonlyInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'name',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Name',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'uid',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'UID',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'mtime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Last modified time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'ctime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Creation time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'depth',
+      inputType: CobblerInputChoices.NUMBER,
+      label: 'Depth',
+      disabled: false,
+      readonly: true,
+      defaultValue: 0,
+      inherited: false,
+    },
+    {
+      formControlName: 'is_subobject',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Is Subobject?',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+  ];
+  managementClassEditableInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'is_definition',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Comment',
+      disabled: true,
+      readonly: false,
+      defaultValue: false,
+      inherited: false,
+    },
+    {
+      formControlName: 'comment',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Comment',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'redhat_management_key',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'RedHat Management Key',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'class_name',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Class Name',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'owners',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Owners',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+    {
+      formControlName: 'params',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Params',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'files',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Files',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+    {
+      formControlName: 'packages',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Packages',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+  ];
 
   // Form
   name: string;
   managementClass: Mgmgtclass;
   private readonly _formBuilder = inject(FormBuilder);
-  managementClassReadonlyFormGroup = this._formBuilder.group({
-    name: new FormControl({ value: '', disabled: false }),
-    uid: new FormControl({ value: '', disabled: false }),
-    mtime: new FormControl({ value: '', disabled: false }),
-    ctime: new FormControl({ value: '', disabled: false }),
-    depth: new FormControl({ value: 0, disabled: false }),
-    is_subobject: new FormControl({ value: false, disabled: false }),
-  });
-  managementClassFormGroup = this._formBuilder.group({
-    is_definition: new FormControl({ value: false, disabled: true }),
-    comment: new FormControl({ value: '', disabled: true }),
-    redhat_management_key: new FormControl({ value: '', disabled: true }),
-    class_name: new FormControl({ value: '', disabled: true }),
-    owners: new FormControl({ value: [], disabled: true }),
-    owners_inherited: new FormControl({ value: false, disabled: true }),
-    params: new FormControl({ value: new Map(), disabled: true }),
-    files: new FormControl({ value: [], disabled: true }),
-    packages: new FormControl({ value: [], disabled: true }),
-  });
+  managementClassReadonlyFormGroup = this._formBuilder.group({});
+  managementClassFormGroup = this._formBuilder.group({});
   isEditMode: boolean = false;
 
   constructor(
@@ -87,14 +202,52 @@ export class ManagementClassEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
+    this.managementClassReadonlyInputData.forEach((value) => {
+      this.managementClassReadonlyFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.managementClassReadonlyFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
+    this.managementClassEditableInputData.forEach((value) => {
+      this.managementClassFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.managementClassFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
   }
 
   ngOnInit(): void {
     this.refreshData();
     // Observables for inherited properties
-    this.managementClassFormGroup.controls.owners_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.managementClassFormGroup.controls.owners),
-    );
+    this.managementClassFormGroup
+      .get('owners_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.managementClassFormGroup.get('owners')),
+      );
   }
 
   ngOnDestroy(): void {
@@ -102,7 +255,9 @@ export class ManagementClassEditComponent implements OnInit, OnDestroy {
     this.ngUnsubscribe.complete();
   }
 
-  getInheritObservable(valueControl: FormControl): (value: boolean) => void {
+  getInheritObservable(
+    valueControl: AbstractControl,
+  ): (value: boolean) => void {
     return (value: boolean): void => {
       if (!this.isEditMode) {
         // If we are not in edit-mode we want to discard processing the event
@@ -120,72 +275,45 @@ export class ManagementClassEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_mgmtclass(this.name, false, false, this.userService.token)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (value) => {
+      .subscribe({
+        next: (value) => {
           this.managementClass = value;
-          this.managementClassReadonlyFormGroup.controls.name.setValue(
-            this.managementClass.name,
-          );
-          this.managementClassReadonlyFormGroup.controls.uid.setValue(
-            this.managementClass.uid,
-          );
-          this.managementClassReadonlyFormGroup.controls.mtime.setValue(
-            new Date(this.managementClass.mtime * 1000).toString(),
-          );
-          this.managementClassReadonlyFormGroup.controls.ctime.setValue(
-            new Date(this.managementClass.ctime * 1000).toString(),
-          );
-          this.managementClassReadonlyFormGroup.controls.depth.setValue(
-            this.managementClass.depth,
-          );
-          this.managementClassReadonlyFormGroup.controls.is_subobject.setValue(
-            this.managementClass.is_subobject,
-          );
-          this.managementClassFormGroup.controls.is_definition.setValue(
-            this.managementClass.is_definition,
-          );
-          this.managementClassFormGroup.controls.comment.setValue(
-            this.managementClass.comment,
-          );
-          this.managementClassFormGroup.controls.class_name.setValue(
-            this.managementClass.class_name,
-          );
-          if (typeof this.managementClass.owners === 'string') {
-            this.managementClassFormGroup.controls.owners_inherited.setValue(
-              true,
-            );
-            this.managementClassFormGroup.controls.owners.setValue([]);
-          } else {
-            this.managementClassFormGroup.controls.owners_inherited.setValue(
-              false,
-            );
-            this.managementClassFormGroup.controls.owners.setValue(
-              this.managementClass.owners,
-            );
-          }
-          this.managementClassFormGroup.controls.params.setValue(
-            this.managementClass.params,
-          );
-          this.managementClassFormGroup.controls.files.setValue(
-            this.managementClass.files,
-          );
-          this.managementClassFormGroup.controls.packages.setValue(
-            this.managementClass.packages,
+          this.managementClassReadonlyFormGroup.patchValue({
+            name: this.managementClass.name,
+            uid: this.managementClass.uid,
+            mtime: Utils.floatToDate(this.managementClass.mtime).toString(),
+            ctime: Utils.floatToDate(this.managementClass.ctime).toString(),
+            depth: this.managementClass.depth,
+            is_subobject: this.managementClass.is_subobject,
+          });
+          this.managementClassFormGroup.patchValue({
+            is_definition: this.managementClass.is_definition,
+            comment: this.managementClass.comment,
+            class_name: this.managementClass.class_name,
+            params: this.managementClass.params,
+            files: this.managementClass.files,
+            packages: this.managementClass.packages,
+          });
+          Utils.patchFormGroupInherited(
+            this.managementClassFormGroup,
+            this.managementClass.owners,
+            'owners',
+            [],
           );
         },
-        (error) => {
+        error: (error) => {
           // HTML encode the error message since it originates from XML
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 
   removeManagementClass(): void {
     this.cobblerApiService
       .remove_mgmtclass(this.name, this.userService.token, false)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (value) => {
+      .subscribe({
+        next: (value) => {
           if (value) {
             this.router.navigate(['/items', 'profile']);
           }
@@ -195,11 +323,11 @@ export class ManagementClassEditComponent implements OnInit, OnDestroy {
             'Close',
           );
         },
-        (error) => {
+        error: (error) => {
           // HTML encode the error message since it originates from XML
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 
   editProfile(): void {
@@ -207,7 +335,7 @@ export class ManagementClassEditComponent implements OnInit, OnDestroy {
     this.managementClassFormGroup.enable();
     // Inherit inputs
     if (typeof this.managementClass.owners === 'string') {
-      this.managementClassFormGroup.controls.owners.disable();
+      this.managementClassFormGroup.get('owners').disable();
     }
   }
 
@@ -236,7 +364,7 @@ export class ManagementClassEditComponent implements OnInit, OnDestroy {
         this.userService.token,
       )
       .subscribe((value) => {
-        const dialogRef = this.dialog.open(DialogBoxItemRenderedComponent, {
+        this.dialog.open(DialogBoxItemRenderedComponent, {
           data: {
             itemType: 'Management Class',
             uid: this.managementClass.uid,
@@ -264,8 +392,8 @@ export class ManagementClassEditComponent implements OnInit, OnDestroy {
       this.cobblerApiService
         .get_mgmtclass_handle(name, this.userService.token)
         .pipe(takeUntil(this.ngUnsubscribe))
-        .subscribe(
-          (mgmtClassHandle) => {
+        .subscribe({
+          next: (mgmtClassHandle) => {
             this.cobblerApiService
               .copy_mgmtclass(
                 mgmtClassHandle,
@@ -273,25 +401,25 @@ export class ManagementClassEditComponent implements OnInit, OnDestroy {
                 this.userService.token,
               )
               .pipe(takeUntil(this.ngUnsubscribe))
-              .subscribe(
-                (value) => {
+              .subscribe({
+                next: () => {
                   this.router.navigate([
                     '/items',
                     'management-class',
                     newItemName,
                   ]);
                 },
-                (error) => {
+                error: (error) => {
                   // HTML encode the error message since it originates from XML
                   this._snackBar.open(Utils.toHTML(error.message), 'Close');
                 },
-              );
+              });
           },
-          (error) => {
+          error: (error) => {
             // HTML encode the error message since it originates from XML
             this._snackBar.open(Utils.toHTML(error.message), 'Close');
           },
-        );
+        });
     });
   }
 
@@ -303,42 +431,42 @@ export class ManagementClassEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_mgmtclass_handle(this.name, this.userService.token)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (managemetClassHandle) => {
+      .subscribe({
+        next: (managementClassHandle) => {
           let modifyObservables: Observable<boolean>[] = [];
           dirtyValues.forEach((value, key) => {
             modifyObservables.push(
               this.cobblerApiService.modify_mgmtclass(
-                managemetClassHandle,
+                managementClassHandle,
                 key,
                 value,
                 this.userService.token,
               ),
             );
           });
-          combineLatest(modifyObservables).subscribe(
-            (value) => {
+          combineLatest(modifyObservables).subscribe({
+            next: () => {
               this.cobblerApiService
-                .save_mgmtclass(managemetClassHandle, this.userService.token)
-                .subscribe(
-                  (value1) => {
+                .save_mgmtclass(managementClassHandle, this.userService.token)
+                .subscribe({
+                  next: () => {
                     this.isEditMode = false;
                     this.managementClassFormGroup.disable();
                     this.refreshData();
                   },
-                  (error) => {
+                  error: (error) => {
                     this._snackBar.open(Utils.toHTML(error.message), 'Close');
                   },
-                );
+                });
             },
-            (error) => {
+            error: (error) => {
               this._snackBar.open(Utils.toHTML(error.message), 'Close');
             },
-          );
+          });
         },
-        (error) => {
+        error: (error) => {
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 }

--- a/projects/cobbler-frontend/src/app/items/management-class/edit/management-class-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/management-class/edit/management-class-edit.component.ts
@@ -2,7 +2,6 @@ import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
   AbstractControl,
   FormBuilder,
-  FormControl,
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
@@ -143,42 +142,12 @@ export class ManagementClassEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
-    this.managementClassReadonlyInputData.forEach((value) => {
-      this.managementClassReadonlyFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.managementClassReadonlyFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
-    this.managementClassEditableInputData.forEach((value) => {
-      this.managementClassFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.managementClassFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
+    Utils.fillupItemFormGroup(
+      this.managementClassReadonlyFormGroup,
+      this.managementClassFormGroup,
+      this.managementClassReadonlyInputData,
+      this.managementClassEditableInputData,
+    );
   }
 
   ngOnInit(): void {

--- a/projects/cobbler-frontend/src/app/items/management-class/edit/management-class-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/management-class/edit/management-class-edit.component.ts
@@ -25,6 +25,10 @@ import { MultiSelectComponent } from '../../../common/multi-select/multi-select.
 import { UserService } from '../../../services/user.service';
 import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
+import {
+  cobblerItemEditableData,
+  cobblerItemReadonlyData,
+} from '../../metadata';
 
 @Component({
   selector: 'cobbler-edit',
@@ -54,63 +58,9 @@ export class ManagementClassEditComponent implements OnInit, OnDestroy {
   private ngUnsubscribe = new Subject<void>();
 
   // Form data
-  managementClassReadonlyInputData: Array<CobblerInputData> = [
-    {
-      formControlName: 'name',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Name',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'uid',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'UID',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'mtime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Last modified time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'ctime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Creation time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'depth',
-      inputType: CobblerInputChoices.NUMBER,
-      label: 'Depth',
-      disabled: false,
-      readonly: true,
-      defaultValue: 0,
-      inherited: false,
-    },
-    {
-      formControlName: 'is_subobject',
-      inputType: CobblerInputChoices.CHECKBOX,
-      label: 'Is Subobject?',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-  ];
+  managementClassReadonlyInputData = cobblerItemReadonlyData;
   managementClassEditableInputData: Array<CobblerInputData> = [
+    ...cobblerItemEditableData,
     {
       formControlName: 'is_definition',
       inputType: CobblerInputChoices.CHECKBOX,
@@ -118,15 +68,6 @@ export class ManagementClassEditComponent implements OnInit, OnDestroy {
       disabled: true,
       readonly: false,
       defaultValue: false,
-      inherited: false,
-    },
-    {
-      formControlName: 'comment',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Comment',
-      disabled: true,
-      readonly: false,
-      defaultValue: '',
       inherited: false,
     },
     {

--- a/projects/cobbler-frontend/src/app/items/menu/edit/menu-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/menu/edit/menu-edit.component.html
@@ -66,41 +66,112 @@
 </div>
 
 <form class="form-replicate" [formGroup]="menuReadonlyFormGroup">
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Name</mat-label>
-    <input matInput type="text" formControlName="name" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>UID</mat-label>
-    <input matInput type="text" formControlName="uid" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Last modified time</mat-label>
-    <input matInput type="text" formControlName="mtime" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Creation time</mat-label>
-    <input matInput type="text" formControlName="ctime" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Depth</mat-label>
-    <input matInput type="number" formControlName="depth" />
-  </mat-form-field>
-  <mat-checkbox class="form-field-full-width" formControlName="is_subobject">
-    Is Subobject?
-  </mat-checkbox>
+  @for (input of menuReadonlyInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+    }
+  }
 </form>
 
 <form class="form-replicate" [formGroup]="menuFormGroup">
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Comment</mat-label>
-    <input matInput type="text" formControlName="comment" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Display Name</mat-label>
-    <input matInput type="text" formControlName="display_name" />
-  </mat-form-field>
+  @for (input of menuEditableInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+      @case (CobblerInputChoices.MULTI_SELECT) {
+        <ng-container class="form-field-full-width">
+          <cobbler-multi-select
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-multi-select>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+      @case (CobblerInputChoices.KEY_VALUE) {
+        <ng-container class="form-field-full-width">
+          <cobbler-key-value-editor
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-key-value-editor>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+    }
+  }
   @if (isEditMode) {
-    <button mat-button (click)="saveMenu()">Save Menu</button>
+    <div>
+      <button mat-button (click)="saveMenu()">Save Menu</button>
+    </div>
   }
 </form>

--- a/projects/cobbler-frontend/src/app/items/menu/edit/menu-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/menu/edit/menu-edit.component.ts
@@ -24,6 +24,10 @@ import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
 import { KeyValueEditorComponent } from '../../../common/key-value-editor/key-value-editor.component';
 import { MultiSelectComponent } from '../../../common/multi-select/multi-select.component';
+import {
+  cobblerItemEditableData,
+  cobblerItemReadonlyData,
+} from '../../metadata';
 
 @Component({
   selector: 'cobbler-edit',
@@ -53,72 +57,9 @@ export class MenuEditComponent implements OnInit, OnDestroy {
   private ngUnsubscribe = new Subject<void>();
 
   // Form data
-  menuReadonlyInputData: Array<CobblerInputData> = [
-    {
-      formControlName: 'name',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Name',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'uid',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'UID',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'mtime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Last modified time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'ctime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Creation time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'depth',
-      inputType: CobblerInputChoices.NUMBER,
-      label: 'Depth',
-      disabled: false,
-      readonly: true,
-      defaultValue: 0,
-      inherited: false,
-    },
-    {
-      formControlName: 'is_subobject',
-      inputType: CobblerInputChoices.CHECKBOX,
-      label: 'Is Subobject?',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-  ];
+  menuReadonlyInputData = cobblerItemReadonlyData;
   menuEditableInputData: Array<CobblerInputData> = [
-    {
-      formControlName: 'comment',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Comment',
-      disabled: true,
-      readonly: false,
-      defaultValue: '',
-      inherited: false,
-    },
+    ...cobblerItemEditableData,
     {
       formControlName: 'display_name',
       inputType: CobblerInputChoices.TEXT,

--- a/projects/cobbler-frontend/src/app/items/menu/edit/menu-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/menu/edit/menu-edit.component.ts
@@ -1,10 +1,5 @@
 import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
-import {
-  FormBuilder,
-  FormControl,
-  FormsModule,
-  ReactiveFormsModule,
-} from '@angular/forms';
+import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
@@ -88,42 +83,12 @@ export class MenuEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
-    this.menuReadonlyInputData.forEach((value) => {
-      this.menuReadonlyFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.menuReadonlyFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
-    this.menuEditableInputData.forEach((value) => {
-      this.menuFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.menuFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
+    Utils.fillupItemFormGroup(
+      this.menuReadonlyFormGroup,
+      this.menuFormGroup,
+      this.menuReadonlyInputData,
+      this.menuEditableInputData,
+    );
   }
 
   ngOnInit(): void {

--- a/projects/cobbler-frontend/src/app/items/metadata.ts
+++ b/projects/cobbler-frontend/src/app/items/metadata.ts
@@ -1,0 +1,70 @@
+import { CobblerInputChoices, CobblerInputData } from '../utils';
+
+export const cobblerItemReadonlyData: Array<CobblerInputData> = [
+  {
+    formControlName: 'name',
+    inputType: CobblerInputChoices.TEXT,
+    label: 'Name',
+    disabled: false,
+    readonly: true,
+    defaultValue: '',
+    inherited: false,
+  },
+  {
+    formControlName: 'uid',
+    inputType: CobblerInputChoices.TEXT,
+    label: 'UID',
+    disabled: false,
+    readonly: true,
+    defaultValue: '',
+    inherited: false,
+  },
+  {
+    formControlName: 'mtime',
+    inputType: CobblerInputChoices.TEXT,
+    label: 'Last modified time',
+    disabled: false,
+    readonly: true,
+    defaultValue: '',
+    inherited: false,
+  },
+  {
+    formControlName: 'ctime',
+    inputType: CobblerInputChoices.TEXT,
+    label: 'Creation time',
+    disabled: false,
+    readonly: true,
+    defaultValue: '',
+    inherited: false,
+  },
+  {
+    formControlName: 'depth',
+    inputType: CobblerInputChoices.NUMBER,
+    label: 'Depth',
+    disabled: false,
+    readonly: true,
+    defaultValue: 0,
+    inherited: false,
+  },
+  {
+    formControlName: 'is_subobject',
+    inputType: CobblerInputChoices.CHECKBOX,
+    label: 'Is Subobject?',
+    disabled: false,
+    readonly: true,
+    defaultValue: false,
+    inherited: false,
+  },
+];
+
+export const cobblerItemEditableData: Array<CobblerInputData> = [
+  {
+    formControlName: 'comment',
+    inputType: CobblerInputChoices.TEXT,
+    label: 'Comment',
+    disabled: true,
+    readonly: false,
+    defaultValue: '',
+    inherited: false,
+  },
+];

--- a/projects/cobbler-frontend/src/app/items/package/edit/package-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/package/edit/package-edit.component.html
@@ -66,76 +66,112 @@
 </div>
 
 <form class="form-replicate" [formGroup]="packageReadonlyFormGroup">
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Name</mat-label>
-    <input matInput type="text" formControlName="name" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>UID</mat-label>
-    <input matInput type="text" formControlName="uid" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Last modified time</mat-label>
-    <input matInput type="text" formControlName="mtime" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Creation time</mat-label>
-    <input matInput type="text" formControlName="ctime" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Depth</mat-label>
-    <input matInput type="number" formControlName="depth" />
-  </mat-form-field>
-  <mat-checkbox class="form-field-full-width" formControlName="is_subobject"
-    >Is Subobject?</mat-checkbox
-  >
+  @for (input of packageReadonlyInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+    }
+  }
 </form>
 
 <form class="form-replicate" [formGroup]="packageFormGroup">
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Comment</mat-label>
-    <input matInput type="text" formControlName="comment" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Mode</mat-label>
-    <input matInput type="text" formControlName="mode" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Owner</mat-label>
-    <input matInput type="text" formControlName="owner" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Group</mat-label>
-    <input matInput type="text" formControlName="group" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Path</mat-label>
-    <input matInput type="text" formControlName="path" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Template</mat-label>
-    <input matInput type="text" formControlName="template" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Action</mat-label>
-    <input matInput type="text" formControlName="action" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Installer</mat-label>
-    <input matInput type="text" formControlName="installer" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Version</mat-label>
-    <input matInput type="text" formControlName="version" />
-  </mat-form-field>
-  <div class="form-field-full-width">
-    <cobbler-multi-select
-      label="Owners"
-      formControlName="owners"
-    ></cobbler-multi-select>
-    <mat-checkbox formControlName="owners_inherited">Inherited</mat-checkbox>
-  </div>
+  @for (input of packageEditableInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+      @case (CobblerInputChoices.MULTI_SELECT) {
+        <ng-container class="form-field-full-width">
+          <cobbler-multi-select
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-multi-select>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+      @case (CobblerInputChoices.KEY_VALUE) {
+        <ng-container class="form-field-full-width">
+          <cobbler-key-value-editor
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-key-value-editor>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+    }
+  }
   @if (isEditMode) {
-    <button mat-button (click)="savePackage()">Save Distro</button>
+    <div>
+      <button mat-button (click)="savePackage()">Save Package</button>
+    </div>
   }
 </form>

--- a/projects/cobbler-frontend/src/app/items/package/edit/package-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/package/edit/package-edit.component.ts
@@ -2,7 +2,6 @@ import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
   AbstractControl,
   FormBuilder,
-  FormControl,
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
@@ -170,42 +169,12 @@ export class PackageEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
-    this.packageReadonlyInputData.forEach((value) => {
-      this.packageReadonlyFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.packageReadonlyFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
-    this.packageEditableInputData.forEach((value) => {
-      this.packageFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.packageFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
+    Utils.fillupItemFormGroup(
+      this.packageReadonlyFormGroup,
+      this.packageFormGroup,
+      this.packageReadonlyInputData,
+      this.packageEditableInputData,
+    );
   }
 
   ngOnInit(): void {

--- a/projects/cobbler-frontend/src/app/items/package/edit/package-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/package/edit/package-edit.component.ts
@@ -25,6 +25,10 @@ import { UserService } from '../../../services/user.service';
 import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
 import { KeyValueEditorComponent } from '../../../common/key-value-editor/key-value-editor.component';
+import {
+  cobblerItemEditableData,
+  cobblerItemReadonlyData,
+} from '../../metadata';
 
 @Component({
   selector: 'cobbler-edit',
@@ -54,72 +58,9 @@ export class PackageEditComponent implements OnInit, OnDestroy {
   private ngUnsubscribe = new Subject<void>();
 
   // Form data
-  packageReadonlyInputData: Array<CobblerInputData> = [
-    {
-      formControlName: 'name',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Name',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'uid',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'UID',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'mtime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Last modified time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'ctime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Creation time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'depth',
-      inputType: CobblerInputChoices.NUMBER,
-      label: 'Depth',
-      disabled: false,
-      readonly: true,
-      defaultValue: 0,
-      inherited: false,
-    },
-    {
-      formControlName: 'is_subobject',
-      inputType: CobblerInputChoices.CHECKBOX,
-      label: 'Is Subobject?',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-  ];
+  packageReadonlyInputData = cobblerItemReadonlyData;
   packageEditableInputData: Array<CobblerInputData> = [
-    {
-      formControlName: 'comment',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Comment',
-      disabled: true,
-      readonly: false,
-      defaultValue: '',
-      inherited: false,
-    },
+    ...cobblerItemEditableData,
     {
       formControlName: 'redhat_management_key',
       inputType: CobblerInputChoices.TEXT,

--- a/projects/cobbler-frontend/src/app/items/package/edit/package-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/package/edit/package-edit.component.ts
@@ -1,18 +1,17 @@
 import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
+  AbstractControl,
   FormBuilder,
   FormControl,
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
-import { MatOption } from '@angular/material/autocomplete';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
-import { MatSelect } from '@angular/material/select';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltip } from '@angular/material/tooltip';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -23,8 +22,9 @@ import { DialogBoxConfirmCancelEditComponent } from '../../../common/dialog-box-
 import { DialogItemCopyComponent } from '../../../common/dialog-item-copy/dialog-item-copy.component';
 import { MultiSelectComponent } from '../../../common/multi-select/multi-select.component';
 import { UserService } from '../../../services/user.service';
-import Utils from '../../../utils';
+import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
+import { KeyValueEditorComponent } from '../../../common/key-value-editor/key-value-editor.component';
 
 @Component({
   selector: 'cobbler-edit',
@@ -38,45 +38,186 @@ import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-
     MatIconButton,
     MatInput,
     MatLabel,
-    MatOption,
-    MatSelect,
     MatTooltip,
     ReactiveFormsModule,
     MultiSelectComponent,
+    KeyValueEditorComponent,
   ],
   templateUrl: './package-edit.component.html',
   styleUrl: './package-edit.component.scss',
 })
 export class PackageEditComponent implements OnInit, OnDestroy {
+  // Bring Enum to HTML scope
+  protected readonly CobblerInputChoices = CobblerInputChoices;
+
   // Unsubscribe
   private ngUnsubscribe = new Subject<void>();
+
+  // Form data
+  packageReadonlyInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'name',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Name',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'uid',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'UID',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'mtime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Last modified time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'ctime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Creation time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'depth',
+      inputType: CobblerInputChoices.NUMBER,
+      label: 'Depth',
+      disabled: false,
+      readonly: true,
+      defaultValue: 0,
+      inherited: false,
+    },
+    {
+      formControlName: 'is_subobject',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Is Subobject?',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+  ];
+  packageEditableInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'comment',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Comment',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'redhat_management_key',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'RedHat Management Key',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'mode',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Mode',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'owner',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Owner',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'group',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Group',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'path',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Path',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'template',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Template',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'action',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Action',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'installer',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Installer',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'version',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Version',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'owners',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Owners',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+  ];
 
   // Form
   name: string;
   package: Package;
   private readonly _formBuilder = inject(FormBuilder);
-  packageReadonlyFormGroup = this._formBuilder.group({
-    name: new FormControl({ value: '', disabled: false }),
-    uid: new FormControl({ value: '', disabled: false }),
-    mtime: new FormControl({ value: '', disabled: false }),
-    ctime: new FormControl({ value: '', disabled: false }),
-    depth: new FormControl({ value: 0, disabled: false }),
-    is_subobject: new FormControl({ value: false, disabled: false }),
-  });
-  packageFormGroup = this._formBuilder.group({
-    comment: new FormControl({ value: '', disabled: true }),
-    redhat_management_key: new FormControl({ value: '', disabled: true }),
-    mode: new FormControl({ value: '', disabled: true }),
-    owner: new FormControl({ value: '', disabled: true }),
-    group: new FormControl({ value: '', disabled: true }),
-    path: new FormControl({ value: '', disabled: true }),
-    template: new FormControl({ value: '', disabled: true }),
-    action: new FormControl({ value: '', disabled: true }),
-    installer: new FormControl({ value: '', disabled: true }),
-    version: new FormControl({ value: '', disabled: true }),
-    owners: new FormControl({ value: [], disabled: true }),
-    owners_inherited: new FormControl({ value: false, disabled: true }),
-  });
+  packageReadonlyFormGroup = this._formBuilder.group({});
+  packageFormGroup = this._formBuilder.group({});
   isEditMode: boolean = false;
 
   constructor(
@@ -88,14 +229,52 @@ export class PackageEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
+    this.packageReadonlyInputData.forEach((value) => {
+      this.packageReadonlyFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.packageReadonlyFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
+    this.packageEditableInputData.forEach((value) => {
+      this.packageFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.packageFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
   }
 
   ngOnInit(): void {
     this.refreshData();
     // Observables for inherited properties
-    this.packageFormGroup.controls.owners_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.packageFormGroup.controls.owners),
-    );
+    this.packageFormGroup
+      .get('owners_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.packageFormGroup.get('owners')),
+      );
   }
 
   ngOnDestroy(): void {
@@ -103,7 +282,9 @@ export class PackageEditComponent implements OnInit, OnDestroy {
     this.ngUnsubscribe.complete();
   }
 
-  getInheritObservable(valueControl: FormControl): (value: boolean) => void {
+  getInheritObservable(
+    valueControl: AbstractControl,
+  ): (value: boolean) => void {
     return (value: boolean): void => {
       if (!this.isEditMode) {
         // If we are not in edit-mode we want to discard processing the event
@@ -124,42 +305,31 @@ export class PackageEditComponent implements OnInit, OnDestroy {
       .subscribe(
         (value) => {
           this.package = value;
-          this.packageReadonlyFormGroup.controls.name.setValue(
-            this.package.name,
+          this.packageReadonlyFormGroup.patchValue({
+            name: this.package.name,
+            uid: this.package.uid,
+            mtime: Utils.floatToDate(this.package.mtime).toString(),
+            ctime: Utils.floatToDate(this.package.ctime).toString(),
+            depth: this.package.depth,
+            is_subobject: this.package.is_subobject,
+          });
+          this.packageFormGroup.patchValue({
+            comment: this.package.comment,
+            mode: this.package.mode,
+            owner: this.package.owner,
+            group: this.package.group,
+            path: this.package.path,
+            template: this.package.template,
+            action: this.package.action,
+            installer: this.package.installer,
+            version: this.package.version,
+          });
+          Utils.patchFormGroupInherited(
+            this.packageFormGroup,
+            this.package.owners,
+            'owners',
+            [],
           );
-          this.packageReadonlyFormGroup.controls.uid.setValue(this.package.uid);
-          this.packageReadonlyFormGroup.controls.mtime.setValue(
-            new Date(this.package.mtime * 1000).toString(),
-          );
-          this.packageReadonlyFormGroup.controls.ctime.setValue(
-            new Date(this.package.ctime * 1000).toString(),
-          );
-          this.packageReadonlyFormGroup.controls.depth.setValue(
-            this.package.depth,
-          );
-          this.packageReadonlyFormGroup.controls.is_subobject.setValue(
-            this.package.is_subobject,
-          );
-          this.packageFormGroup.controls.comment.setValue(this.package.comment);
-          this.packageFormGroup.controls.mode.setValue(this.package.mode);
-          this.packageFormGroup.controls.owner.setValue(this.package.owner);
-          this.packageFormGroup.controls.group.setValue(this.package.group);
-          this.packageFormGroup.controls.path.setValue(this.package.path);
-          this.packageFormGroup.controls.template.setValue(
-            this.package.template,
-          );
-          this.packageFormGroup.controls.action.setValue(this.package.action);
-          this.packageFormGroup.controls.installer.setValue(
-            this.package.installer,
-          );
-          this.packageFormGroup.controls.version.setValue(this.package.version);
-          if (typeof this.package.owners === 'string') {
-            this.packageFormGroup.controls.owners_inherited.setValue(true);
-            this.packageFormGroup.controls.owners.setValue([]);
-          } else {
-            this.packageFormGroup.controls.owners_inherited.setValue(false);
-            this.packageFormGroup.controls.owners.setValue(this.package.owners);
-          }
         },
         (error) => {
           // HTML encode the error message since it originates from XML
@@ -172,8 +342,8 @@ export class PackageEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .remove_package(this.name, this.userService.token, false)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (value) => {
+      .subscribe({
+        next: (value) => {
           if (value) {
             this.router.navigate(['/items', 'package']);
           }
@@ -183,11 +353,11 @@ export class PackageEditComponent implements OnInit, OnDestroy {
             'Close',
           );
         },
-        (error) => {
+        error: (error) => {
           // HTML encode the error message since it originates from XML
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 
   editPackage(): void {
@@ -195,7 +365,7 @@ export class PackageEditComponent implements OnInit, OnDestroy {
     this.packageFormGroup.enable();
     // Inherit inputs
     if (typeof this.package.owners === 'string') {
-      this.packageFormGroup.controls.owners.disable();
+      this.packageFormGroup.get('owners').disable();
     }
   }
 
@@ -221,7 +391,7 @@ export class PackageEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_package_as_rendered(this.package.name, this.userService.token)
       .subscribe((value) => {
-        const dialogRef = this.dialog.open(DialogBoxItemRenderedComponent, {
+        this.dialog.open(DialogBoxItemRenderedComponent, {
           data: {
             itemType: 'Package',
             uid: this.package.uid,
@@ -249,26 +419,26 @@ export class PackageEditComponent implements OnInit, OnDestroy {
       this.cobblerApiService
         .get_package_handle(name, this.userService.token)
         .pipe(takeUntil(this.ngUnsubscribe))
-        .subscribe(
-          (packageHandle) => {
+        .subscribe({
+          next: (packageHandle) => {
             this.cobblerApiService
               .copy_package(packageHandle, newItemName, this.userService.token)
               .pipe(takeUntil(this.ngUnsubscribe))
-              .subscribe(
-                (value) => {
+              .subscribe({
+                next: () => {
                   this.router.navigate(['/items', 'package', newItemName]);
                 },
-                (error) => {
+                error: (error) => {
                   // HTML encode the error message since it originates from XML
                   this._snackBar.open(Utils.toHTML(error.message), 'Close');
                 },
-              );
+              });
           },
-          (error) => {
+          error: (error) => {
             // HTML encode the error message since it originates from XML
             this._snackBar.open(Utils.toHTML(error.message), 'Close');
           },
-        );
+        });
     });
   }
 
@@ -280,8 +450,8 @@ export class PackageEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_package_handle(this.name, this.userService.token)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (packageHandle) => {
+      .subscribe({
+        next: (packageHandle) => {
           let modifyObservables: Observable<boolean>[] = [];
           dirtyValues.forEach((value, key) => {
             modifyObservables.push(
@@ -293,29 +463,29 @@ export class PackageEditComponent implements OnInit, OnDestroy {
               ),
             );
           });
-          combineLatest(modifyObservables).subscribe(
-            (value) => {
+          combineLatest(modifyObservables).subscribe({
+            next: () => {
               this.cobblerApiService
                 .save_package(packageHandle, this.userService.token)
-                .subscribe(
-                  (value1) => {
+                .subscribe({
+                  next: () => {
                     this.isEditMode = false;
                     this.packageFormGroup.disable();
                     this.refreshData();
                   },
-                  (error) => {
+                  error: (error) => {
                     this._snackBar.open(Utils.toHTML(error.message), 'Close');
                   },
-                );
+                });
             },
-            (error) => {
+            error: (error) => {
               this._snackBar.open(Utils.toHTML(error.message), 'Close');
             },
-          );
+          });
         },
-        (error) => {
+        error: (error) => {
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 }

--- a/projects/cobbler-frontend/src/app/items/profile/edit/profile-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/profile/edit/profile-edit.component.html
@@ -76,193 +76,113 @@
 </div>
 
 <form class="form-replicate" [formGroup]="profileReadonlyFormGroup">
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Name</mat-label>
-    <input matInput type="text" formControlName="name" [readonly]="true" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>UID</mat-label>
-    <input matInput type="text" formControlName="uid" [readonly]="true" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Last modified time</mat-label>
-    <input matInput type="text" formControlName="mtime" [readonly]="true" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Creation time</mat-label>
-    <input matInput type="text" formControlName="ctime" [readonly]="true" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Depth</mat-label>
-    <input matInput type="number" formControlName="depth" [readonly]="true" />
-  </mat-form-field>
-  <mat-checkbox
-    class="form-field-full-width"
-    formControlName="is_subobject"
-    [disableRipple]="true"
-    (click)="$event.preventDefault()"
-  >
-    Is Subobject?
-  </mat-checkbox>
+  @for (input of profileReadonlyInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+    }
+  }
 </form>
 
 <form class="form-replicate" [formGroup]="profileFormGroup">
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Boot Loaders"
-      formControlName="boot_loaders"
-    ></cobbler-multi-select>
-    <mat-checkbox formControlName="boot_loaders_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Comment</mat-label>
-    <input matInput type="text" formControlName="comment" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Autoinstall</mat-label>
-    <input matInput type="text" formControlName="autoinstall" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>DHCP Tag</mat-label>
-    <input matInput type="text" formControlName="dhcp_tag" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Distribution</mat-label>
-    <input matInput type="text" formControlName="distro" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Menu</mat-label>
-    <input matInput type="text" formControlName="menu" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Next-Server IPv4</mat-label>
-    <input matInput type="text" formControlName="next_server_v4" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Next-Server IPv6</mat-label>
-    <input matInput type="text" formControlName="next_server_v6" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Filename</mat-label>
-    <input matInput type="text" formControlName="filename" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Parent</mat-label>
-    <input matInput type="text" formControlName="parent" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Proxy</mat-label>
-    <input matInput type="text" formControlName="proxy" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>RedHat Management Key</mat-label>
-    <input matInput type="text" formControlName="redhat_management_key" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Server</mat-label>
-    <input matInput type="text" formControlName="server" />
-  </mat-form-field>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Automatic Installation Template Metadata"
-      formControlName="autoinstall_meta"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="autoinstall_meta_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="TFTP Boot Files"
-      formControlName="boot_files"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="boot_files_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Fetchable Files"
-      formControlName="fetchable_files"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="fetchable_files_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Kernel Options"
-      formControlName="kernel_options"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="kernel_options_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Kernel Options (Post Install)"
-      formControlName="kernel_options_post"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="kernel_options_post_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Management Classes"
-      formControlName="mgmt_classes"
-    ></cobbler-multi-select>
-    <mat-checkbox formControlName="mgmt_classes_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Management Parameters"
-      formControlName="mgmt_parameters"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="mgmt_parameters_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Name Servers"
-      formControlName="name_servers"
-    ></cobbler-multi-select>
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Name Servers Search Path"
-      formControlName="name_servers_search"
-    ></cobbler-multi-select>
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Owners"
-      formControlName="owners"
-    ></cobbler-multi-select>
-    <mat-checkbox formControlName="owners_inherited">Inherited</mat-checkbox>
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Repos"
-      formControlName="repos"
-    ></cobbler-multi-select>
-  </ng-container>
-  <div class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Template Files"
-      formControlName="template_files"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="template_files_inherited"
-      >Inherited</mat-checkbox
-    >
-  </div>
+  @for (input of profileEditableInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+      @case (CobblerInputChoices.MULTI_SELECT) {
+        <ng-container class="form-field-full-width">
+          <cobbler-multi-select
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-multi-select>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+      @case (CobblerInputChoices.KEY_VALUE) {
+        <ng-container class="form-field-full-width">
+          <cobbler-key-value-editor
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-key-value-editor>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+    }
+  }
   <!-- TODO: virt options -->
   @if (isEditMode) {
-    <button mat-button (click)="saveProfile()">Save Distro</button>
+    <div>
+      <button mat-button (click)="saveProfile()">Save Profile</button>
+    </div>
   }
 </form>

--- a/projects/cobbler-frontend/src/app/items/profile/edit/profile-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/profile/edit/profile-edit.component.ts
@@ -2,7 +2,6 @@ import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
   AbstractControl,
   FormBuilder,
-  FormControl,
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
@@ -296,42 +295,12 @@ export class ProfileEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
-    this.profileReadonlyInputData.forEach((value) => {
-      this.profileReadonlyFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.profileReadonlyFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
-    this.profileEditableInputData.forEach((value) => {
-      this.profileFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.profileFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
+    Utils.fillupItemFormGroup(
+      this.profileReadonlyFormGroup,
+      this.profileFormGroup,
+      this.profileReadonlyInputData,
+      this.profileEditableInputData,
+    );
   }
 
   ngOnInit(): void {

--- a/projects/cobbler-frontend/src/app/items/profile/edit/profile-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/profile/edit/profile-edit.component.ts
@@ -1,18 +1,17 @@
 import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
+  AbstractControl,
   FormBuilder,
   FormControl,
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
-import { MatOption } from '@angular/material/autocomplete';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
-import { MatSelect } from '@angular/material/select';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltip } from '@angular/material/tooltip';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -24,7 +23,7 @@ import { DialogItemCopyComponent } from '../../../common/dialog-item-copy/dialog
 import { KeyValueEditorComponent } from '../../../common/key-value-editor/key-value-editor.component';
 import { MultiSelectComponent } from '../../../common/multi-select/multi-select.component';
 import { UserService } from '../../../services/user.service';
-import Utils from '../../../utils';
+import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
 
 @Component({
@@ -40,8 +39,6 @@ import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-
     MatFormField,
     MatInput,
     MatLabel,
-    MatOption,
-    MatSelect,
     ReactiveFormsModule,
     MultiSelectComponent,
     KeyValueEditorComponent,
@@ -50,70 +47,303 @@ import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-
   styleUrl: './profile-edit.component.scss',
 })
 export class ProfileEditComponent implements OnInit, OnDestroy {
+  // Bring Enum to HTML scope
+  protected readonly CobblerInputChoices = CobblerInputChoices;
+
   // Unsubscribe
   private ngUnsubscribe = new Subject<void>();
+
+  // Form data
+  profileReadonlyInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'name',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Name',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'uid',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'UID',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'mtime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Last modified time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'ctime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Creation time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'depth',
+      inputType: CobblerInputChoices.NUMBER,
+      label: 'Depth',
+      disabled: false,
+      readonly: true,
+      defaultValue: 0,
+      inherited: false,
+    },
+    {
+      formControlName: 'is_subobject',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Is Subobject?',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+  ];
+  profileEditableInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'comment',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Comment',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'redhat_management_key',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'RedHat Management Key',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'autoinstall',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Autoinstallation Template',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'dhcp_tag',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'DHCP Tag',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'distro',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Distro',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'menu',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Menu',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'next_server_v4',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Next Server IPv4',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'next_server_v6',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Next Server IPv6',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'filename',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'DHCP Filename',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'parent',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Parent',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'proxy',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Proxy',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'server',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Server',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'boot_loaders',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Boot Loaders',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+    {
+      formControlName: 'owners',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Owners',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+    {
+      formControlName: 'autoinstall_meta',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Automatic Installation Template Metadata',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'boot_files',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'TFTP Boot Files',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'fetchable_files',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Fetchable Files',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'kernel_options',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Kernel Options',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'kernel_options_post',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Kernel Options (Post Install)',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'mgmt_classes',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Management Classes',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+    {
+      formControlName: 'mgmt_parameters',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Management Parameters',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'name_servers',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Name Servers',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: false,
+    },
+    {
+      formControlName: 'name_servers_search',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Name Servers Search',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: false,
+    },
+    {
+      formControlName: 'repos',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Repositories',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: false,
+    },
+    {
+      formControlName: 'template_files',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Template Files',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+  ];
 
   // Form
   name: string;
   profile: Profile;
   private readonly _formBuilder = inject(FormBuilder);
-  profileReadonlyFormGroup = this._formBuilder.group({
-    name: new FormControl({ value: '', disabled: false }),
-    uid: new FormControl({ value: '', disabled: false }),
-    mtime: new FormControl({ value: '', disabled: false }),
-    ctime: new FormControl({ value: '', disabled: false }),
-    depth: new FormControl({ value: 0, disabled: false }),
-    is_subobject: new FormControl({ value: false, disabled: false }),
-  });
-  profileFormGroup = this._formBuilder.group({
-    comment: new FormControl({ value: '', disabled: true }),
-    redhat_management_key: new FormControl({ value: '', disabled: true }),
-    autoinstall: new FormControl({ value: '', disabled: true }),
-    dhcp_tag: new FormControl({ value: '', disabled: true }),
-    distro: new FormControl({ value: '', disabled: true }),
-    menu: new FormControl({ value: '', disabled: true }),
-    next_server_v4: new FormControl({ value: '', disabled: true }),
-    next_server_v6: new FormControl({ value: '', disabled: true }),
-    filename: new FormControl({ value: '', disabled: true }),
-    parent: new FormControl({ value: '', disabled: true }),
-    proxy: new FormControl({ value: '', disabled: true }),
-    server: new FormControl({ value: '', disabled: true }),
-    boot_loaders: new FormControl({ value: [], disabled: true }),
-    boot_loaders_inherited: new FormControl({ value: false, disabled: true }),
-    owners: new FormControl({ value: [], disabled: true }),
-    owners_inherited: new FormControl({ value: false, disabled: true }),
-    autoinstall_meta: new FormControl({ value: new Map(), disabled: true }),
-    autoinstall_meta_inherited: new FormControl({
-      value: false,
-      disabled: true,
-    }),
-    boot_files: new FormControl({ value: new Map(), disabled: true }),
-    boot_files_inherited: new FormControl({ value: false, disabled: true }),
-    fetchable_files: new FormControl({ value: new Map(), disabled: true }),
-    fetchable_files_inherited: new FormControl({
-      value: false,
-      disabled: true,
-    }),
-    kernel_options: new FormControl({ value: new Map(), disabled: true }),
-    kernel_options_inherited: new FormControl({ value: false, disabled: true }),
-    kernel_options_post: new FormControl({ value: new Map(), disabled: true }),
-    kernel_options_post_inherited: new FormControl({
-      value: false,
-      disabled: true,
-    }),
-    mgmt_classes: new FormControl({ value: [], disabled: true }),
-    mgmt_classes_inherited: new FormControl({ value: false, disabled: true }),
-    mgmt_parameters: new FormControl({ value: new Map(), disabled: true }),
-    mgmt_parameters_inherited: new FormControl({
-      value: false,
-      disabled: true,
-    }),
-    name_servers: new FormControl({ value: [], disabled: true }),
-    name_servers_search: new FormControl({ value: [], disabled: true }),
-    repos: new FormControl({ value: [], disabled: true }),
-    template_files: new FormControl({ value: new Map(), disabled: true }),
-    template_files_inherited: new FormControl({ value: false, disabled: true }),
-  });
+  profileReadonlyFormGroup = this._formBuilder.group({});
+  profileFormGroup = this._formBuilder.group({});
   isEditMode: boolean = false;
 
   constructor(
@@ -125,45 +355,101 @@ export class ProfileEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
+    this.profileReadonlyInputData.forEach((value) => {
+      this.profileReadonlyFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.profileReadonlyFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
+    this.profileEditableInputData.forEach((value) => {
+      this.profileFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.profileFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
   }
 
   ngOnInit(): void {
     this.refreshData();
     // Observables for inherited properties
-    this.profileFormGroup.controls.autoinstall_meta_inherited.valueChanges.subscribe(
-      this.getInheritObservable(
-        this.profileFormGroup.controls.autoinstall_meta,
-      ),
-    );
-    this.profileFormGroup.controls.boot_files_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.profileFormGroup.controls.boot_files),
-    );
-    this.profileFormGroup.controls.boot_loaders_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.profileFormGroup.controls.boot_loaders),
-    );
-    this.profileFormGroup.controls.fetchable_files_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.profileFormGroup.controls.fetchable_files),
-    );
-    this.profileFormGroup.controls.kernel_options_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.profileFormGroup.controls.kernel_options),
-    );
-    this.profileFormGroup.controls.kernel_options_post_inherited.valueChanges.subscribe(
-      this.getInheritObservable(
-        this.profileFormGroup.controls.kernel_options_post,
-      ),
-    );
-    this.profileFormGroup.controls.mgmt_classes_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.profileFormGroup.controls.mgmt_classes),
-    );
-    this.profileFormGroup.controls.mgmt_parameters_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.profileFormGroup.controls.mgmt_parameters),
-    );
-    this.profileFormGroup.controls.owners_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.profileFormGroup.controls.owners),
-    );
-    this.profileFormGroup.controls.template_files_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.profileFormGroup.controls.template_files),
-    );
+    this.profileFormGroup
+      .get('autoinstall_meta_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(
+          this.profileFormGroup.get('autoinstall_meta'),
+        ),
+      );
+    this.profileFormGroup
+      .get('boot_files_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.profileFormGroup.get('boot_files')),
+      );
+    this.profileFormGroup
+      .get('boot_loaders_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.profileFormGroup.get('boot_loaders')),
+      );
+    this.profileFormGroup
+      .get('fetchable_files_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.profileFormGroup.get('fetchable_files')),
+      );
+    this.profileFormGroup
+      .get('kernel_options_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.profileFormGroup.get('kernel_options')),
+      );
+    this.profileFormGroup
+      .get('kernel_options_post_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(
+          this.profileFormGroup.get('kernel_options_post'),
+        ),
+      );
+    this.profileFormGroup
+      .get('mgmt_classes_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.profileFormGroup.get('mgmt_classes')),
+      );
+    this.profileFormGroup
+      .get('mgmt_parameters_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.profileFormGroup.get('mgmt_parameters')),
+      );
+    this.profileFormGroup
+      .get('owners_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.profileFormGroup.get('owners')),
+      );
+    this.profileFormGroup
+      .get('template_files_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.profileFormGroup.get('template_files')),
+      );
   }
 
   ngOnDestroy(): void {
@@ -171,7 +457,9 @@ export class ProfileEditComponent implements OnInit, OnDestroy {
     this.ngUnsubscribe.complete();
   }
 
-  getInheritObservable(valueControl: FormControl): (value: boolean) => void {
+  getInheritObservable(
+    valueControl: AbstractControl,
+  ): (value: boolean) => void {
     return (value: boolean): void => {
       if (!this.isEditMode) {
         // If we are not in edit-mode we want to discard processing the event
@@ -193,180 +481,108 @@ export class ProfileEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_profile(this.name, false, false, this.userService.token)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (value) => {
+      .subscribe({
+        next: (value) => {
           this.profile = value;
-          this.profileReadonlyFormGroup.controls.name.setValue(
-            this.profile.name,
+          this.profileReadonlyFormGroup.patchValue({
+            name: this.profile.name,
+            uid: this.profile.uid,
+            mtime: Utils.floatToDate(this.profile.mtime).toString(),
+            ctime: Utils.floatToDate(this.profile.ctime).toString(),
+            depth: this.profile.depth,
+            is_subobject: this.profile.is_subobject,
+          });
+          this.profileFormGroup.patchValue({
+            comment: this.profile.comment,
+            redhat_management_key: this.profile.redhat_management_key,
+            autoinstall: this.profile.autoinstall,
+            dhcp_tag: this.profile.dhcp_tag,
+            distro: this.profile.distro,
+            menu: this.profile.menu,
+            next_server_v4: this.profile.next_server_v4,
+            next_server_v6: this.profile.next_server_v6,
+            filename: this.profile.filename,
+            parent: this.profile.parent,
+            proxy: this.profile.proxy,
+            server: this.profile.server,
+            name_servers: this.profile.name_servers,
+            name_servers_search: this.profile.name_servers_search,
+            repos: this.profile.repos,
+          });
+          Utils.patchFormGroupInherited(
+            this.profileFormGroup,
+            this.profile.boot_loaders,
+            'boot_loaders',
+            [],
           );
-          this.profileReadonlyFormGroup.controls.uid.setValue(this.profile.uid);
-          this.profileReadonlyFormGroup.controls.mtime.setValue(
-            new Date(this.profile.mtime * 1000).toString(),
+          Utils.patchFormGroupInherited(
+            this.profileFormGroup,
+            this.profile.owners,
+            'owners',
+            [],
           );
-          this.profileReadonlyFormGroup.controls.ctime.setValue(
-            new Date(this.profile.ctime * 1000).toString(),
+          Utils.patchFormGroupInherited(
+            this.profileFormGroup,
+            this.profile.autoinstall_meta,
+            'autoinstall_meta',
+            new Map<string, any>(),
           );
-          this.profileReadonlyFormGroup.controls.depth.setValue(
-            this.profile.depth,
+          Utils.patchFormGroupInherited(
+            this.profileFormGroup,
+            this.profile.boot_files,
+            'boot_files',
+            new Map<string, any>(),
           );
-          this.profileReadonlyFormGroup.controls.is_subobject.setValue(
-            this.profile.is_subobject,
+          Utils.patchFormGroupInherited(
+            this.profileFormGroup,
+            this.profile.fetchable_files,
+            'fetchable_files',
+            new Map<string, any>(),
           );
-          this.profileFormGroup.controls.comment.setValue(this.profile.comment);
-          this.profileFormGroup.controls.redhat_management_key.setValue(
-            this.profile.redhat_management_key,
+          Utils.patchFormGroupInherited(
+            this.profileFormGroup,
+            this.profile.kernel_options,
+            'kernel_options',
+            new Map<string, any>(),
           );
-          this.profileFormGroup.controls.autoinstall.setValue(
-            this.profile.autoinstall,
+          Utils.patchFormGroupInherited(
+            this.profileFormGroup,
+            this.profile.kernel_options_post,
+            'kernel_options_post',
+            new Map<string, any>(),
           );
-          this.profileFormGroup.controls.dhcp_tag.setValue(
-            this.profile.dhcp_tag,
+          Utils.patchFormGroupInherited(
+            this.profileFormGroup,
+            this.profile.mgmt_classes,
+            'mgmt_classes',
+            [],
           );
-          this.profileFormGroup.controls.distro.setValue(this.profile.distro);
-          this.profileFormGroup.controls.menu.setValue(this.profile.menu);
-          this.profileFormGroup.controls.next_server_v4.setValue(
-            this.profile.next_server_v4,
+          Utils.patchFormGroupInherited(
+            this.profileFormGroup,
+            this.profile.mgmt_parameters,
+            'mgmt_parameters',
+            new Map<string, any>(),
           );
-          this.profileFormGroup.controls.next_server_v6.setValue(
-            this.profile.next_server_v6,
+          Utils.patchFormGroupInherited(
+            this.profileFormGroup,
+            this.profile.template_files,
+            'template_files',
+            new Map<string, any>(),
           );
-          this.profileFormGroup.controls.filename.setValue(
-            this.profile.filename,
-          );
-          this.profileFormGroup.controls.parent.setValue(this.profile.parent);
-          this.profileFormGroup.controls.proxy.setValue(this.profile.proxy);
-          this.profileFormGroup.controls.server.setValue(this.profile.server);
-          this.profileFormGroup.controls.name_servers.setValue(
-            this.profile.name_servers,
-          );
-          this.profileFormGroup.controls.name_servers_search.setValue(
-            this.profile.name_servers_search,
-          );
-          this.profileFormGroup.controls.repos.setValue(this.profile.repos);
-          if (typeof this.profile.boot_loaders === 'string') {
-            this.profileFormGroup.controls.boot_loaders_inherited.setValue(
-              true,
-            );
-          } else {
-            this.profileFormGroup.controls.boot_loaders_inherited.setValue(
-              false,
-            );
-            this.profileFormGroup.controls.boot_loaders.setValue(
-              this.profile.boot_loaders,
-            );
-          }
-          if (typeof this.profile.owners === 'string') {
-            this.profileFormGroup.controls.owners_inherited.setValue(true);
-          } else {
-            this.profileFormGroup.controls.owners_inherited.setValue(false);
-            this.profileFormGroup.controls.owners.setValue(this.profile.owners);
-          }
-          if (typeof this.profile.autoinstall_meta === 'string') {
-            this.profileFormGroup.controls.autoinstall_meta_inherited.setValue(
-              true,
-            );
-          } else {
-            this.profileFormGroup.controls.autoinstall_meta_inherited.setValue(
-              false,
-            );
-            this.profileFormGroup.controls.autoinstall_meta.setValue(
-              this.profile.autoinstall_meta,
-            );
-          }
-          if (typeof this.profile.boot_files === 'string') {
-            this.profileFormGroup.controls.boot_files_inherited.setValue(true);
-          } else {
-            this.profileFormGroup.controls.boot_files_inherited.setValue(false);
-            this.profileFormGroup.controls.boot_files.setValue(
-              this.profile.boot_files,
-            );
-          }
-          if (typeof this.profile.fetchable_files === 'string') {
-            this.profileFormGroup.controls.fetchable_files_inherited.setValue(
-              true,
-            );
-          } else {
-            this.profileFormGroup.controls.fetchable_files_inherited.setValue(
-              false,
-            );
-            this.profileFormGroup.controls.fetchable_files.setValue(
-              this.profile.fetchable_files,
-            );
-          }
-          if (typeof this.profile.kernel_options === 'string') {
-            this.profileFormGroup.controls.kernel_options_inherited.setValue(
-              true,
-            );
-          } else {
-            this.profileFormGroup.controls.kernel_options_inherited.setValue(
-              false,
-            );
-            this.profileFormGroup.controls.kernel_options.setValue(
-              this.profile.kernel_options,
-            );
-          }
-          if (typeof this.profile.kernel_options_post === 'string') {
-            this.profileFormGroup.controls.kernel_options_post_inherited.setValue(
-              true,
-            );
-          } else {
-            this.profileFormGroup.controls.kernel_options_post_inherited.setValue(
-              false,
-            );
-            this.profileFormGroup.controls.kernel_options_post.setValue(
-              this.profile.kernel_options_post,
-            );
-          }
-          if (typeof this.profile.mgmt_classes === 'string') {
-            this.profileFormGroup.controls.mgmt_classes_inherited.setValue(
-              true,
-            );
-          } else {
-            this.profileFormGroup.controls.mgmt_classes_inherited.setValue(
-              false,
-            );
-            this.profileFormGroup.controls.mgmt_classes.setValue(
-              this.profile.mgmt_classes,
-            );
-          }
-          if (typeof this.profile.mgmt_parameters === 'string') {
-            this.profileFormGroup.controls.mgmt_parameters_inherited.setValue(
-              true,
-            );
-          } else {
-            this.profileFormGroup.controls.mgmt_parameters_inherited.setValue(
-              false,
-            );
-            this.profileFormGroup.controls.mgmt_parameters.setValue(
-              this.profile.mgmt_parameters,
-            );
-          }
-          if (typeof this.profile.template_files === 'string') {
-            this.profileFormGroup.controls.template_files_inherited.setValue(
-              true,
-            );
-          } else {
-            this.profileFormGroup.controls.template_files_inherited.setValue(
-              false,
-            );
-            this.profileFormGroup.controls.template_files.setValue(
-              this.profile.template_files,
-            );
-          }
         },
-        (error) => {
+        error: (error) => {
           // HTML encode the error message since it originates from XML
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 
   removeProfile(): void {
     this.cobblerApiService
       .remove_profile(this.name, this.userService.token, false)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (value) => {
+      .subscribe({
+        next: (value) => {
           if (value) {
             this.router.navigate(['/items', 'profile']);
           }
@@ -376,11 +592,11 @@ export class ProfileEditComponent implements OnInit, OnDestroy {
             'Close',
           );
         },
-        (error) => {
+        error: (error) => {
           // HTML encode the error message since it originates from XML
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 
   editProfile(): void {
@@ -388,34 +604,34 @@ export class ProfileEditComponent implements OnInit, OnDestroy {
     this.profileFormGroup.enable();
     // Inherit inputs
     if (typeof this.profile.autoinstall_meta === 'string') {
-      this.profileFormGroup.controls.autoinstall_meta.disable();
+      this.profileFormGroup.get('autoinstall_meta').disable();
     }
     if (typeof this.profile.boot_files === 'string') {
-      this.profileFormGroup.controls.boot_files.disable();
+      this.profileFormGroup.get('boot_files').disable();
     }
     if (typeof this.profile.boot_loaders === 'string') {
-      this.profileFormGroup.controls.boot_loaders.disable();
+      this.profileFormGroup.get('boot_loaders').disable();
     }
     if (typeof this.profile.fetchable_files === 'string') {
-      this.profileFormGroup.controls.fetchable_files.disable();
+      this.profileFormGroup.get('fetchable_files').disable();
     }
     if (typeof this.profile.kernel_options === 'string') {
-      this.profileFormGroup.controls.kernel_options.disable();
+      this.profileFormGroup.get('kernel_options').disable();
     }
     if (typeof this.profile.kernel_options_post === 'string') {
-      this.profileFormGroup.controls.kernel_options_post.disable();
+      this.profileFormGroup.get('kernel_options_post').disable();
     }
     if (typeof this.profile.mgmt_classes === 'string') {
-      this.profileFormGroup.controls.mgmt_classes.disable();
+      this.profileFormGroup.get('mgmt_classes').disable();
     }
     if (typeof this.profile.mgmt_parameters === 'string') {
-      this.profileFormGroup.controls.mgmt_parameters.disable();
+      this.profileFormGroup.get('mgmt_parameters').disable();
     }
     if (typeof this.profile.owners === 'string') {
-      this.profileFormGroup.controls.owners.disable();
+      this.profileFormGroup.get('owners').disable();
     }
     if (typeof this.profile.template_files === 'string') {
-      this.profileFormGroup.controls.template_files.disable();
+      this.profileFormGroup.get('template_files').disable();
     }
   }
 
@@ -441,7 +657,7 @@ export class ProfileEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_profile_as_rendered(this.profile.name, this.userService.token)
       .subscribe((value) => {
-        const dialogRef = this.dialog.open(DialogBoxItemRenderedComponent, {
+        this.dialog.open(DialogBoxItemRenderedComponent, {
           data: {
             itemType: 'Profile',
             uid: this.profile.uid,
@@ -475,7 +691,7 @@ export class ProfileEditComponent implements OnInit, OnDestroy {
               .copy_profile(profileHandle, newItemName, this.userService.token)
               .pipe(takeUntil(this.ngUnsubscribe))
               .subscribe({
-                next: (value) => {
+                next: () => {
                   this.router.navigate(['/items', 'profile', newItemName]);
                 },
                 error: (error) => {
@@ -514,11 +730,11 @@ export class ProfileEditComponent implements OnInit, OnDestroy {
             );
           });
           combineLatest(modifyObservables).subscribe({
-            next: (value) => {
+            next: () => {
               this.cobblerApiService
                 .save_profile(profileHandle, this.userService.token)
                 .subscribe({
-                  next: (value1) => {
+                  next: () => {
                     this.isEditMode = false;
                     this.profileFormGroup.disable();
                     this.refreshData();

--- a/projects/cobbler-frontend/src/app/items/profile/edit/profile-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/profile/edit/profile-edit.component.ts
@@ -25,6 +25,10 @@ import { MultiSelectComponent } from '../../../common/multi-select/multi-select.
 import { UserService } from '../../../services/user.service';
 import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
+import {
+  cobblerItemEditableData,
+  cobblerItemReadonlyData,
+} from '../../metadata';
 
 @Component({
   selector: 'cobbler-edit',
@@ -54,72 +58,9 @@ export class ProfileEditComponent implements OnInit, OnDestroy {
   private ngUnsubscribe = new Subject<void>();
 
   // Form data
-  profileReadonlyInputData: Array<CobblerInputData> = [
-    {
-      formControlName: 'name',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Name',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'uid',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'UID',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'mtime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Last modified time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'ctime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Creation time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'depth',
-      inputType: CobblerInputChoices.NUMBER,
-      label: 'Depth',
-      disabled: false,
-      readonly: true,
-      defaultValue: 0,
-      inherited: false,
-    },
-    {
-      formControlName: 'is_subobject',
-      inputType: CobblerInputChoices.CHECKBOX,
-      label: 'Is Subobject?',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-  ];
+  profileReadonlyInputData = cobblerItemReadonlyData;
   profileEditableInputData: Array<CobblerInputData> = [
-    {
-      formControlName: 'comment',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Comment',
-      disabled: true,
-      readonly: false,
-      defaultValue: '',
-      inherited: false,
-    },
+    ...cobblerItemEditableData,
     {
       formControlName: 'redhat_management_key',
       inputType: CobblerInputChoices.TEXT,

--- a/projects/cobbler-frontend/src/app/items/repository/edit/repository-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/repository/edit/repository-edit.component.html
@@ -66,107 +66,112 @@
 </div>
 
 <form class="form-replicate" [formGroup]="repositoryReadonlyFormGroup">
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Name</mat-label>
-    <input matInput type="text" formControlName="name" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>UID</mat-label>
-    <input matInput type="text" formControlName="uid" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Last modified time</mat-label>
-    <input matInput type="text" formControlName="mtime" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Creation time</mat-label>
-    <input matInput type="text" formControlName="ctime" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Depth</mat-label>
-    <input matInput type="number" formControlName="depth" />
-  </mat-form-field>
-  <mat-checkbox class="form-field-full-width" formControlName="is_subobject"
-    >Is Subobject?</mat-checkbox
-  >
+  @for (input of repositoryReadonlyInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+    }
+  }
 </form>
 
 <form class="form-replicate" [formGroup]="repositoryFormGroup">
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Comment</mat-label>
-    <input matInput type="text" formControlName="comment" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Operating System Version</mat-label>
-    <input matInput type="text" formControlName="os_version" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Operating System Breed</mat-label>
-    <input matInput type="text" formControlName="breed" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Mirror</mat-label>
-    <input matInput type="text" formControlName="mirror" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Mirror Type</mat-label>
-    <input matInput type="text" formControlName="mirror_type" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Proxy</mat-label>
-    <input matInput type="text" formControlName="proxy" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Priority</mat-label>
-    <input matInput type="number" formControlName="priority" />
-  </mat-form-field>
-  <mat-checkbox class="form-field-full-width" formControlName="keep_updated"
-    >Keep updated?</mat-checkbox
-  >
-  <mat-checkbox class="form-field-full-width" formControlName="mirror_locally"
-    >Mirror Locally?</mat-checkbox
-  >
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Apt Components"
-      formControlName="apt_components"
-    ></cobbler-multi-select>
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Environment Variables"
-      formControlName="environment"
-    ></cobbler-key-value-editor>
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Apt Dist Names"
-      formControlName="apt_dists"
-    ></cobbler-multi-select>
-  </ng-container>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Createrepo Flags</mat-label>
-    <input matInput type="text" formControlName="createrepo_flags" />
-  </mat-form-field>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="RPM List"
-      formControlName="rpm_list"
-    ></cobbler-multi-select>
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Yum Options"
-      formControlName="yumopts"
-    ></cobbler-key-value-editor>
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Rsync Options"
-      formControlName="rsyncopts"
-    ></cobbler-key-value-editor>
-  </ng-container>
+  @for (input of repositoryEditableInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+      @case (CobblerInputChoices.MULTI_SELECT) {
+        <ng-container class="form-field-full-width">
+          <cobbler-multi-select
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-multi-select>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+      @case (CobblerInputChoices.KEY_VALUE) {
+        <ng-container class="form-field-full-width">
+          <cobbler-key-value-editor
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-key-value-editor>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+    }
+  }
   @if (isEditMode) {
-    <button mat-button (click)="saveRepository()">Save Distro</button>
+    <div>
+      <button mat-button (click)="saveRepository()">Save Repository</button>
+    </div>
   }
 </form>

--- a/projects/cobbler-frontend/src/app/items/repository/edit/repository-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/repository/edit/repository-edit.component.ts
@@ -2,7 +2,6 @@ import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
   AbstractControl,
   FormBuilder,
-  FormControl,
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
@@ -233,42 +232,12 @@ export class RepositoryEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
-    this.repositoryReadonlyInputData.forEach((value) => {
-      this.repositoryReadonlyFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.repositoryReadonlyFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
-    this.repositoryEditableInputData.forEach((value) => {
-      this.repositoryFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.repositoryFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
+    Utils.fillupItemFormGroup(
+      this.repositoryReadonlyFormGroup,
+      this.repositoryFormGroup,
+      this.repositoryReadonlyInputData,
+      this.repositoryEditableInputData,
+    );
   }
 
   ngOnInit(): void {

--- a/projects/cobbler-frontend/src/app/items/repository/edit/repository-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/repository/edit/repository-edit.component.ts
@@ -1,18 +1,17 @@
 import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
+  AbstractControl,
   FormBuilder,
   FormControl,
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
-import { MatOption } from '@angular/material/autocomplete';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
-import { MatSelect } from '@angular/material/select';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltip } from '@angular/material/tooltip';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -24,7 +23,7 @@ import { DialogItemCopyComponent } from '../../../common/dialog-item-copy/dialog
 import { KeyValueEditorComponent } from '../../../common/key-value-editor/key-value-editor.component';
 import { MultiSelectComponent } from '../../../common/multi-select/multi-select.component';
 import { UserService } from '../../../services/user.service';
-import Utils from '../../../utils';
+import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
 
 @Component({
@@ -39,8 +38,6 @@ import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-
     MatIconButton,
     MatInput,
     MatLabel,
-    MatOption,
-    MatSelect,
     MatTooltip,
     ReactiveFormsModule,
     MultiSelectComponent,
@@ -50,42 +47,240 @@ import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-
   styleUrl: './repository-edit.component.scss',
 })
 export class RepositoryEditComponent implements OnInit, OnDestroy {
+  // Bring Enum to HTML scope
+  protected readonly CobblerInputChoices = CobblerInputChoices;
+
   // Unsubscribe
   private ngUnsubscribe = new Subject<void>();
+
+  // Form data
+  repositoryReadonlyInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'name',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Name',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'uid',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'UID',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'mtime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Last modified time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'ctime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Creation time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'depth',
+      inputType: CobblerInputChoices.NUMBER,
+      label: 'Depth',
+      disabled: false,
+      readonly: true,
+      defaultValue: 0,
+      inherited: false,
+    },
+    {
+      formControlName: 'is_subobject',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Is Subobject?',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+  ];
+  repositoryEditableInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'priority',
+      inputType: CobblerInputChoices.NUMBER,
+      label: 'Priority',
+      disabled: true,
+      readonly: false,
+      defaultValue: 0,
+      inherited: false,
+    },
+    {
+      formControlName: 'keep_updated',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Keep Updated?',
+      disabled: true,
+      readonly: false,
+      defaultValue: false,
+      inherited: false,
+    },
+    {
+      formControlName: 'mirror_locally',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Mirror locally?',
+      disabled: true,
+      readonly: false,
+      defaultValue: false,
+      inherited: false,
+    },
+    {
+      formControlName: 'comment',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Comment',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'redhat_management_key',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'RedHat Management Key',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'mirror_type',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Mirror Type',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'mirror',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Mirror',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'breed',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Breed',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'os_version',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'OS Version',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'proxy',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Proxy',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'createrepo_flags',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'createrepo Flags',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'owners',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Owners',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+    {
+      formControlName: 'apt_components',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'APT Components',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: false,
+    },
+    {
+      formControlName: 'apt_dists',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'APT Dists',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: false,
+    },
+    {
+      formControlName: 'rpm_list',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'RPM List',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: false,
+    },
+    {
+      formControlName: 'environment',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Environment Variables',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: false,
+    },
+    {
+      formControlName: 'yumopts',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'YUM Options',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: false,
+    },
+    {
+      formControlName: 'rsyncopts',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'rsync Options',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: false,
+    },
+  ];
 
   // Form
   name: string;
   repository: Repo;
   private readonly _formBuilder = inject(FormBuilder);
-  repositoryReadonlyFormGroup = this._formBuilder.group({
-    name: new FormControl({ value: '', disabled: false }),
-    uid: new FormControl({ value: '', disabled: false }),
-    mtime: new FormControl({ value: '', disabled: false }),
-    ctime: new FormControl({ value: '', disabled: false }),
-    depth: new FormControl({ value: 0, disabled: false }),
-    is_subobject: new FormControl({ value: false, disabled: false }),
-  });
-  repositoryFormGroup = this._formBuilder.group({
-    priority: new FormControl({ value: 0, disabled: true }),
-    keep_updated: new FormControl({ value: false, disabled: true }),
-    mirror_locally: new FormControl({ value: false, disabled: true }),
-    comment: new FormControl({ value: '', disabled: true }),
-    redhat_management_key: new FormControl({ value: '', disabled: true }),
-    mirror_type: new FormControl({ value: '', disabled: true }),
-    mirror: new FormControl({ value: '', disabled: true }),
-    breed: new FormControl({ value: '', disabled: true }),
-    os_version: new FormControl({ value: '', disabled: true }),
-    proxy: new FormControl({ value: '', disabled: true }),
-    createrepo_flags: new FormControl({ value: '', disabled: true }),
-    owners: new FormControl({ value: [], disabled: true }),
-    owners_inherited: new FormControl({ value: false, disabled: true }),
-    apt_components: new FormControl({ value: [], disabled: true }),
-    apt_dists: new FormControl({ value: [], disabled: true }),
-    rpm_list: new FormControl({ value: [], disabled: true }),
-    environment: new FormControl({ value: new Map(), disabled: true }),
-    yumopts: new FormControl({ value: new Map(), disabled: true }),
-    rsyncopts: new FormControl({ value: new Map(), disabled: true }),
-  });
+  repositoryReadonlyFormGroup = this._formBuilder.group({});
+  repositoryFormGroup = this._formBuilder.group({});
   isEditMode: boolean = false;
 
   constructor(
@@ -97,14 +292,52 @@ export class RepositoryEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
+    this.repositoryReadonlyInputData.forEach((value) => {
+      this.repositoryReadonlyFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.repositoryReadonlyFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
+    this.repositoryEditableInputData.forEach((value) => {
+      this.repositoryFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.repositoryFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
   }
 
   ngOnInit(): void {
     this.refreshData();
     // Observables for inherited properties
-    this.repositoryFormGroup.controls.owners_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.repositoryFormGroup.controls.owners),
-    );
+    this.repositoryFormGroup
+      .get('owners_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.repositoryFormGroup.get('owners')),
+      );
   }
 
   ngOnDestroy(): void {
@@ -112,7 +345,9 @@ export class RepositoryEditComponent implements OnInit, OnDestroy {
     this.ngUnsubscribe.complete();
   }
 
-  getInheritObservable(valueControl: FormControl): (value: boolean) => void {
+  getInheritObservable(
+    valueControl: AbstractControl,
+  ): (value: boolean) => void {
     return (value: boolean): void => {
       if (!this.isEditMode) {
         // If we are not in edit-mode we want to discard processing the event
@@ -130,110 +365,70 @@ export class RepositoryEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_repo(this.name, false, false, this.userService.token)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (value) => {
+      .subscribe({
+        next: (value) => {
           this.repository = value;
-          this.repositoryReadonlyFormGroup.controls.name.setValue(
-            this.repository.name,
+          this.repositoryReadonlyFormGroup.patchValue({
+            name: this.repository.name,
+            uid: this.repository.uid,
+            mtime: Utils.floatToDate(this.repository.mtime).toString(),
+            ctime: Utils.floatToDate(this.repository.ctime).toString(),
+            depth: this.repository.depth,
+            is_subobject: this.repository.is_subobject,
+          });
+          this.repositoryFormGroup.patchValue({
+            priority: this.repository.priority,
+            keep_updated: this.repository.keep_updated,
+            mirror_locally: this.repository.mirror_locally,
+            comment: this.repository.comment,
+            proxy: this.repository.proxy,
+            mirror_type: this.repository.mirror_type,
+            mirror: this.repository.mirror,
+            breed: this.repository.breed,
+            os_version: this.repository.os_version,
+            creatrepo_flags: this.repository.createrepo_flags,
+            rpm_list: this.repository.rpm_list,
+            apt_dists: this.repository.apt_dists,
+            apt_components: this.repository.apt_components,
+          });
+          Utils.patchFormGroupInherited(
+            this.repositoryFormGroup,
+            this.repository.owners,
+            'owners',
+            [],
           );
-          this.repositoryReadonlyFormGroup.controls.uid.setValue(
-            this.repository.uid,
+          Utils.patchFormGroupInherited(
+            this.repositoryFormGroup,
+            this.repository.environment,
+            'environment',
+            new Map(),
           );
-          this.repositoryReadonlyFormGroup.controls.mtime.setValue(
-            new Date(this.repository.mtime * 1000).toString(),
+          Utils.patchFormGroupInherited(
+            this.repositoryFormGroup,
+            this.repository.yumopts,
+            'yumopts',
+            new Map(),
           );
-          this.repositoryReadonlyFormGroup.controls.ctime.setValue(
-            new Date(this.repository.ctime * 1000).toString(),
+          Utils.patchFormGroupInherited(
+            this.repositoryFormGroup,
+            this.repository.rsyncopts,
+            'rsyncopts',
+            new Map(),
           );
-          this.repositoryReadonlyFormGroup.controls.depth.setValue(
-            this.repository.depth,
-          );
-          this.repositoryReadonlyFormGroup.controls.is_subobject.setValue(
-            this.repository.is_subobject,
-          );
-          this.repositoryFormGroup.controls.priority.setValue(
-            this.repository.priority,
-          );
-          this.repositoryFormGroup.controls.keep_updated.setValue(
-            this.repository.keep_updated,
-          );
-          this.repositoryFormGroup.controls.mirror_locally.setValue(
-            this.repository.mirror_locally,
-          );
-          this.repositoryFormGroup.controls.comment.setValue(
-            this.repository.comment,
-          );
-          this.repositoryFormGroup.controls.proxy.setValue(
-            this.repository.proxy,
-          );
-          this.repositoryFormGroup.controls.mirror_type.setValue(
-            this.repository.mirror_type,
-          );
-          this.repositoryFormGroup.controls.mirror.setValue(
-            this.repository.mirror,
-          );
-          this.repositoryFormGroup.controls.breed.setValue(
-            this.repository.breed,
-          );
-          this.repositoryFormGroup.controls.os_version.setValue(
-            this.repository.os_version,
-          );
-          this.repositoryFormGroup.controls.createrepo_flags.setValue(
-            this.repository.createrepo_flags,
-          );
-          this.repositoryFormGroup.controls.rpm_list.setValue(
-            this.repository.rpm_list,
-          );
-          this.repositoryFormGroup.controls.apt_dists.setValue(
-            this.repository.apt_dists,
-          );
-          this.repositoryFormGroup.controls.apt_components.setValue(
-            this.repository.apt_components,
-          );
-          if (typeof this.repository.owners === 'string') {
-            this.repositoryFormGroup.controls.owners_inherited.setValue(true);
-            this.repositoryFormGroup.controls.owners.setValue([]);
-          } else {
-            this.repositoryFormGroup.controls.owners_inherited.setValue(false);
-            this.repositoryFormGroup.controls.owners.setValue(
-              this.repository.owners,
-            );
-          }
-          if (typeof this.repository.environment === 'string') {
-            this.repositoryFormGroup.controls.environment.setValue(new Map());
-          } else {
-            this.repositoryFormGroup.controls.environment.setValue(
-              this.repository.environment,
-            );
-          }
-          if (typeof this.repository.yumopts === 'string') {
-            this.repositoryFormGroup.controls.yumopts.setValue(new Map());
-          } else {
-            this.repositoryFormGroup.controls.yumopts.setValue(
-              this.repository.yumopts,
-            );
-          }
-          if (typeof this.repository.rsyncopts === 'string') {
-            this.repositoryFormGroup.controls.rsyncopts.setValue(new Map());
-          } else {
-            this.repositoryFormGroup.controls.rsyncopts.setValue(
-              this.repository.rsyncopts,
-            );
-          }
         },
-        (error) => {
+        error: (error) => {
           // HTML encode the error message since it originates from XML
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 
   removeRepository(): void {
     this.cobblerApiService
       .remove_repo(this.name, this.userService.token, false)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (value) => {
+      .subscribe({
+        next: (value) => {
           if (value) {
             this.router.navigate(['/items', 'repository']);
           }
@@ -243,11 +438,11 @@ export class RepositoryEditComponent implements OnInit, OnDestroy {
             'Close',
           );
         },
-        (error) => {
+        error: (error) => {
           // HTML encode the error message since it originates from XML
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 
   editRepository(): void {
@@ -255,7 +450,7 @@ export class RepositoryEditComponent implements OnInit, OnDestroy {
     this.repositoryFormGroup.enable();
     // Inherit inputs
     if (typeof this.repository.owners === 'string') {
-      this.repositoryFormGroup.controls.owners.disable();
+      this.repositoryFormGroup.get('owners').disable();
     }
   }
 
@@ -281,7 +476,7 @@ export class RepositoryEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_repo_as_rendered(this.repository.name, this.userService.token)
       .subscribe((value) => {
-        const dialogRef = this.dialog.open(DialogBoxItemRenderedComponent, {
+        this.dialog.open(DialogBoxItemRenderedComponent, {
           data: {
             itemType: 'Repository',
             uid: this.repository.uid,
@@ -309,26 +504,26 @@ export class RepositoryEditComponent implements OnInit, OnDestroy {
       this.cobblerApiService
         .get_repo_handle(name, this.userService.token)
         .pipe(takeUntil(this.ngUnsubscribe))
-        .subscribe(
-          (repositoryHandle) => {
+        .subscribe({
+          next: (repositoryHandle) => {
             this.cobblerApiService
               .copy_repo(repositoryHandle, newItemName, this.userService.token)
               .pipe(takeUntil(this.ngUnsubscribe))
-              .subscribe(
-                (value) => {
+              .subscribe({
+                next: () => {
                   this.router.navigate(['/items', 'repository', newItemName]);
                 },
-                (error) => {
+                error: (error) => {
                   // HTML encode the error message since it originates from XML
                   this._snackBar.open(Utils.toHTML(error.message), 'Close');
                 },
-              );
+              });
           },
-          (error) => {
+          error: (error) => {
             // HTML encode the error message since it originates from XML
             this._snackBar.open(Utils.toHTML(error.message), 'Close');
           },
-        );
+        });
     });
   }
 
@@ -340,8 +535,8 @@ export class RepositoryEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_repo_handle(this.name, this.userService.token)
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(
-        (repositoryHandle) => {
+      .subscribe({
+        next: (repositoryHandle) => {
           let modifyObservables: Observable<boolean>[] = [];
           dirtyValues.forEach((value, key) => {
             modifyObservables.push(
@@ -353,29 +548,29 @@ export class RepositoryEditComponent implements OnInit, OnDestroy {
               ),
             );
           });
-          combineLatest(modifyObservables).subscribe(
-            (value) => {
+          combineLatest(modifyObservables).subscribe({
+            next: () => {
               this.cobblerApiService
                 .save_repo(repositoryHandle, this.userService.token)
-                .subscribe(
-                  (value1) => {
+                .subscribe({
+                  next: () => {
                     this.isEditMode = false;
                     this.repositoryFormGroup.disable();
                     this.refreshData();
                   },
-                  (error) => {
+                  error: (error) => {
                     this._snackBar.open(Utils.toHTML(error.message), 'Close');
                   },
-                );
+                });
             },
-            (error) => {
+            error: (error) => {
               this._snackBar.open(Utils.toHTML(error.message), 'Close');
             },
-          );
+          });
         },
-        (error) => {
+        error: (error) => {
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 }

--- a/projects/cobbler-frontend/src/app/items/repository/edit/repository-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/repository/edit/repository-edit.component.ts
@@ -25,6 +25,10 @@ import { MultiSelectComponent } from '../../../common/multi-select/multi-select.
 import { UserService } from '../../../services/user.service';
 import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
+import {
+  cobblerItemEditableData,
+  cobblerItemReadonlyData,
+} from '../../metadata';
 
 @Component({
   selector: 'cobbler-edit',
@@ -54,63 +58,9 @@ export class RepositoryEditComponent implements OnInit, OnDestroy {
   private ngUnsubscribe = new Subject<void>();
 
   // Form data
-  repositoryReadonlyInputData: Array<CobblerInputData> = [
-    {
-      formControlName: 'name',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Name',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'uid',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'UID',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'mtime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Last modified time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'ctime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Creation time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'depth',
-      inputType: CobblerInputChoices.NUMBER,
-      label: 'Depth',
-      disabled: false,
-      readonly: true,
-      defaultValue: 0,
-      inherited: false,
-    },
-    {
-      formControlName: 'is_subobject',
-      inputType: CobblerInputChoices.CHECKBOX,
-      label: 'Is Subobject?',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-  ];
+  repositoryReadonlyInputData = cobblerItemReadonlyData;
   repositoryEditableInputData: Array<CobblerInputData> = [
+    ...cobblerItemEditableData,
     {
       formControlName: 'priority',
       inputType: CobblerInputChoices.NUMBER,
@@ -136,15 +86,6 @@ export class RepositoryEditComponent implements OnInit, OnDestroy {
       disabled: true,
       readonly: false,
       defaultValue: false,
-      inherited: false,
-    },
-    {
-      formControlName: 'comment',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Comment',
-      disabled: true,
-      readonly: false,
-      defaultValue: '',
       inherited: false,
     },
     {

--- a/projects/cobbler-frontend/src/app/items/system/edit/system-edit.component.html
+++ b/projects/cobbler-frontend/src/app/items/system/edit/system-edit.component.html
@@ -91,275 +91,112 @@
 <!-- TODO: Use tabs to separate system and power options -->
 
 <form class="form-replicate" [formGroup]="systemReadonlyFormGroup">
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Name</mat-label>
-    <input matInput type="text" formControlName="name" [readonly]="true" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>UID</mat-label>
-    <input matInput type="text" formControlName="uid" [readonly]="true" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Last modified time</mat-label>
-    <input matInput type="text" formControlName="mtime" [readonly]="true" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Creation time</mat-label>
-    <input matInput type="text" formControlName="ctime" [readonly]="true" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Depth</mat-label>
-    <input matInput type="number" formControlName="depth" [readonly]="true" />
-  </mat-form-field>
-  <mat-checkbox
-    class="form-field-full-width"
-    formControlName="is_subobject"
-    [disableRipple]="true"
-    (click)="$event.preventDefault()"
-  >
-    Is Subobject?
-  </mat-checkbox>
+  @for (input of systemReadonlyInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+    }
+  }
 </form>
 
 <form class="form-replicate" [formGroup]="systemFormGroup">
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Boot Loaders"
-      formControlName="boot_loaders"
-    ></cobbler-multi-select>
-    <mat-checkbox formControlName="boot_loaders_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Comment</mat-label>
-    <input matInput type="text" formControlName="comment" />
-  </mat-form-field>
-  <mat-checkbox
-    class="form-field-full-width"
-    formControlName="ipv6_autoconfiguration"
-    >IPv6 Auto Configuration?</mat-checkbox
-  >
-  <mat-checkbox class="form-field-full-width" formControlName="repos_enabled"
-    >Repositories enabled?</mat-checkbox
-  >
-  <mat-checkbox class="form-field-full-width" formControlName="netboot_enabled"
-    >Network boot enabled?</mat-checkbox
-  >
-  <mat-checkbox class="form-field-full-width" formControlName="virt_auto_boot"
-    >VM auto boot?</mat-checkbox
-  >
-  <mat-checkbox class="form-field-full-width" formControlName="virt_pxe_boot"
-    >VM PXE boot?</mat-checkbox
-  >
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Autoinstall</mat-label>
-    <input matInput type="text" formControlName="autoinstall" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Parent</mat-label>
-    <input matInput type="text" formControlName="parent" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Gateway</mat-label>
-    <input matInput type="text" formControlName="gateway" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Hostname</mat-label>
-    <input matInput type="text" formControlName="hostname" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Image</mat-label>
-    <input matInput type="text" formControlName="image" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>IPv6 Default Device</mat-label>
-    <input matInput type="text" formControlName="ipv6_default_device" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Next Server IPv4</mat-label>
-    <input matInput type="text" formControlName="next_server_v4" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Next Server IPv6</mat-label>
-    <input matInput type="text" formControlName="next_server_v6" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>DHCP Filename</mat-label>
-    <input matInput type="text" formControlName="filename" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Power Address</mat-label>
-    <input matInput type="text" formControlName="power_address" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Power ID</mat-label>
-    <input matInput type="text" formControlName="power_id" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Power Password</mat-label>
-    <input matInput type="text" formControlName="power_pass" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Power Type</mat-label>
-    <input matInput type="text" formControlName="power_type" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Power Username</mat-label>
-    <input matInput type="text" formControlName="power_user" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Power Options</mat-label>
-    <input matInput type="text" formControlName="power_options" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Power Identity File</mat-label>
-    <input matInput type="text" formControlName="power_identity_file" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Profile</mat-label>
-    <input matInput type="text" formControlName="profile" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Proxy</mat-label>
-    <input matInput type="text" formControlName="proxy" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>RedHat Management Key</mat-label>
-    <input matInput type="text" formControlName="redhat_management_key" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Server</mat-label>
-    <input matInput type="text" formControlName="server" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Status</mat-label>
-    <input matInput type="text" formControlName="status" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>VM Disk Driver</mat-label>
-    <input matInput type="text" formControlName="virt_disk_driver" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>VM Path</mat-label>
-    <input matInput type="text" formControlName="virt_path" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>VM Type</mat-label>
-    <input matInput type="text" formControlName="virt_type" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>VM CPUs</mat-label>
-    <input matInput type="number" formControlName="virt_cpus" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>VM File Size</mat-label>
-    <input matInput type="number" formControlName="virt_file_size" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>VM RAM</mat-label>
-    <input matInput type="number" formControlName="virt_ram" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Serial Device</mat-label>
-    <input matInput type="number" formControlName="serial_device" />
-  </mat-form-field>
-  <mat-form-field class="form-field-full-width">
-    <mat-label>Serial Baud Rate</mat-label>
-    <input matInput type="number" formControlName="serial_baud_rate" />
-  </mat-form-field>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Automatic Installation Template Metadata"
-      formControlName="autoinstall_meta"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="autoinstall_meta_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="TFTP Boot Files"
-      formControlName="boot_files"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="boot_files_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Fetchable Files"
-      formControlName="fetchable_files"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="fetchable_files_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Kernel Options"
-      formControlName="kernel_options"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="kernel_options_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Kernel Options (Post Install)"
-      formControlName="kernel_options_post"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="kernel_options_post_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Management Classes"
-      formControlName="mgmt_classes"
-    ></cobbler-multi-select>
-    <mat-checkbox formControlName="mgmt_classes_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Management Parameters"
-      formControlName="mgmt_parameters"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="mgmt_parameters_inherited"
-      >Inherited</mat-checkbox
-    >
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Name Servers"
-      formControlName="name_servers"
-    ></cobbler-multi-select>
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Name Servers Search Path"
-      formControlName="name_servers_search"
-    ></cobbler-multi-select>
-  </ng-container>
-  <ng-container class="form-field-full-width">
-    <cobbler-multi-select
-      label="Owners"
-      formControlName="owners"
-    ></cobbler-multi-select>
-    <mat-checkbox formControlName="owners_inherited">Inherited</mat-checkbox>
-  </ng-container>
-  <div class="form-field-full-width">
-    <cobbler-key-value-editor
-      label="Template Files"
-      formControlName="template_files"
-    ></cobbler-key-value-editor>
-    <mat-checkbox formControlName="template_files_inherited"
-      >Inherited</mat-checkbox
-    >
-  </div>
+  @for (input of systemEditableInputData; track input) {
+    @switch (input.inputType) {
+      @case (CobblerInputChoices.TEXT) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.NUMBER) {
+        <mat-form-field class="form-field-full-width">
+          <mat-label>{{ input.label }}</mat-label>
+          <input
+            matInput
+            type="{{ input.inputType }}"
+            formControlName="{{ input.formControlName }}"
+            readonly="{{ input.readonly }}"
+          />
+        </mat-form-field>
+      }
+      @case (CobblerInputChoices.CHECKBOX) {
+        <mat-checkbox
+          class="form-field-full-width"
+          formControlName="{{ input.formControlName }}"
+          [disableRipple]="true"
+          (click)="$event.preventDefault()"
+        >
+          {{ input.label }}
+        </mat-checkbox>
+      }
+      @case (CobblerInputChoices.MULTI_SELECT) {
+        <ng-container class="form-field-full-width">
+          <cobbler-multi-select
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-multi-select>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+      @case (CobblerInputChoices.KEY_VALUE) {
+        <ng-container class="form-field-full-width">
+          <cobbler-key-value-editor
+            label="{{ input.label }}"
+            formControlName="{{ input.formControlName }}"
+          ></cobbler-key-value-editor>
+          @if (input.inherited) {
+            <mat-checkbox
+              formControlName="{{ input.formControlName }}_inherited"
+              >Inherited</mat-checkbox
+            >
+          }
+        </ng-container>
+      }
+    }
+  }
   @if (isEditMode) {
-    <button mat-button (click)="saveSystem()">Save Distro</button>
+    <div>
+      <button mat-button (click)="saveSystem()">Save System</button>
+    </div>
   }
 </form>

--- a/projects/cobbler-frontend/src/app/items/system/edit/system-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/system/edit/system-edit.component.ts
@@ -1,5 +1,6 @@
 import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
+  AbstractControl,
   FormBuilder,
   FormControl,
   FormsModule,
@@ -22,9 +23,8 @@ import { DialogItemCopyComponent } from '../../../common/dialog-item-copy/dialog
 import { KeyValueEditorComponent } from '../../../common/key-value-editor/key-value-editor.component';
 import { MultiSelectComponent } from '../../../common/multi-select/multi-select.component';
 import { UserService } from '../../../services/user.service';
-import Utils from '../../../utils';
+import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
-import { MatMenuItem } from '@angular/material/menu';
 
 @Component({
   selector: 'cobbler-edit',
@@ -42,98 +42,506 @@ import { MatMenuItem } from '@angular/material/menu';
     ReactiveFormsModule,
     MultiSelectComponent,
     KeyValueEditorComponent,
-    MatMenuItem,
   ],
   templateUrl: './system-edit.component.html',
   styleUrl: './system-edit.component.scss',
 })
 export class SystemEditComponent implements OnInit, OnDestroy {
+  // Bring Enum to HTML scope
+  protected readonly CobblerInputChoices = CobblerInputChoices;
+
   // Unsubscribe
   private ngUnsubscribe = new Subject<void>();
+
+  // Form data
+  systemReadonlyInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'name',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Name',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'uid',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'UID',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'mtime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Last modified time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'ctime',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Creation time',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'depth',
+      inputType: CobblerInputChoices.NUMBER,
+      label: 'Depth',
+      disabled: false,
+      readonly: true,
+      defaultValue: 0,
+      inherited: false,
+    },
+    {
+      formControlName: 'is_subobject',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Is Subobject?',
+      disabled: false,
+      readonly: true,
+      defaultValue: '',
+      inherited: false,
+    },
+  ];
+  systemEditableInputData: Array<CobblerInputData> = [
+    {
+      formControlName: 'virt_cpus',
+      inputType: CobblerInputChoices.NUMBER,
+      label: 'Virtual CPUs',
+      disabled: true,
+      readonly: false,
+      defaultValue: 0,
+      inherited: false,
+    },
+    {
+      formControlName: 'virt_file_size',
+      inputType: CobblerInputChoices.NUMBER,
+      label: 'Virtual Disk File Size',
+      disabled: true,
+      readonly: false,
+      defaultValue: 0,
+      inherited: false,
+    },
+    {
+      formControlName: 'virt_ram',
+      inputType: CobblerInputChoices.NUMBER,
+      label: 'Virtual RAM',
+      disabled: true,
+      readonly: false,
+      defaultValue: 0,
+      inherited: false,
+    },
+    {
+      formControlName: 'serial_device',
+      inputType: CobblerInputChoices.NUMBER,
+      label: 'Serial Device Number',
+      disabled: true,
+      readonly: false,
+      defaultValue: 0,
+      inherited: false,
+    },
+    {
+      formControlName: 'serial_baud_rate',
+      inputType: CobblerInputChoices.NUMBER,
+      label: 'Serial Device Baud Rate',
+      disabled: true,
+      readonly: false,
+      defaultValue: 0,
+      inherited: false,
+    },
+    {
+      formControlName: 'comment',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Comment',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'redhat_management_key',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'RedHat Management Key',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'autoinstall',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Autoinstallation Template',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'parent',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Parent',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'gateway',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Gateway',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'hostname',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Hostname',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'image',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Image',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'ipv6_default_device',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'IPv6 Default Device',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'next_server_v4',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Next Server IPv4',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'next_server_v6',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Next Server IPv6',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'filename',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'DHCP Filename',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'power_address',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Power Management Address',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'power_id',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Power Management Plug ID',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'power_pass',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Power Management Password',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'power_type',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Power Management Type',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'power_user',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Power Management Username',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'power_options',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Power Management Options',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'power_identity_file',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Power Management Identity File',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'profile',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Profile',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'proxy',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Proxy',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'server',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Server',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'status',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Status',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'virt_disk_driver',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Virtual Disk Driver',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'virt_path',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Virtual Image Path',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'virt_type',
+      inputType: CobblerInputChoices.TEXT,
+      label: 'Virtual Machine Type',
+      disabled: true,
+      readonly: false,
+      defaultValue: '',
+      inherited: false,
+    },
+    {
+      formControlName: 'boot_loaders',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Boot Loaders',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+    {
+      formControlName: 'ipv6_autoconfiguration',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Use IPv6 Autoconfiguration?',
+      disabled: true,
+      readonly: false,
+      defaultValue: false,
+      inherited: false,
+    },
+    {
+      formControlName: 'repos_enabled',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Repositories enabled?',
+      disabled: true,
+      readonly: false,
+      defaultValue: false,
+      inherited: false,
+    },
+    {
+      formControlName: 'netboot_enabled',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Network Boot enabled?',
+      disabled: true,
+      readonly: false,
+      defaultValue: false,
+      inherited: false,
+    },
+    {
+      formControlName: 'virt_auto_boot',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Virtual Machine Auto Boot?',
+      disabled: true,
+      readonly: false,
+      defaultValue: false,
+      inherited: false,
+    },
+    {
+      formControlName: 'virt_pxe_boot',
+      inputType: CobblerInputChoices.CHECKBOX,
+      label: 'Virtual PXE Boot?',
+      disabled: true,
+      readonly: false,
+      defaultValue: false,
+      inherited: false,
+    },
+    {
+      formControlName: 'owners',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Owners',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+    {
+      formControlName: 'boot_files',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'TFTP Boot Files',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'fetchable_files',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Fetchable Files',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'kernel_options',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Kernel Options',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'kernel_options_post',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Kernel Options (Post Install)',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'mgmt_classes',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Management Classes',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: true,
+    },
+    {
+      formControlName: 'mgmt_parameters',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Management Parameters',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'template_files',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Template Files',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'autoinstall_meta',
+      inputType: CobblerInputChoices.KEY_VALUE,
+      label: 'Automatic Installation Template Metadata',
+      disabled: true,
+      readonly: false,
+      defaultValue: new Map<string, any>(),
+      inherited: true,
+    },
+    {
+      formControlName: 'name_servers',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Name Servers',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: false,
+    },
+    {
+      formControlName: 'name_servers_search',
+      inputType: CobblerInputChoices.MULTI_SELECT,
+      label: 'Name Servers Search',
+      disabled: true,
+      readonly: false,
+      defaultValue: [],
+      inherited: false,
+    },
+  ];
 
   // Form
   name: string;
   system: System;
   private readonly _formBuilder = inject(FormBuilder);
-  systemReadonlyFormGroup = this._formBuilder.group({
-    name: new FormControl({ value: '', disabled: false }),
-    uid: new FormControl({ value: '', disabled: false }),
-    mtime: new FormControl({ value: '', disabled: false }),
-    ctime: new FormControl({ value: '', disabled: false }),
-    depth: new FormControl({ value: 0, disabled: false }),
-    is_subobject: new FormControl({ value: false, disabled: false }),
-  });
-  systemFormGroup = this._formBuilder.group({
-    virt_cpus: new FormControl({ value: 0, disabled: true }),
-    virt_file_size: new FormControl({ value: 0, disabled: true }),
-    virt_ram: new FormControl({ value: 0, disabled: true }),
-    serial_device: new FormControl({ value: 0, disabled: true }),
-    serial_baud_rate: new FormControl({ value: 0, disabled: true }),
-    comment: new FormControl({ value: '', disabled: true }),
-    redhat_management_key: new FormControl({ value: '', disabled: true }),
-    autoinstall: new FormControl({ value: '', disabled: true }),
-    parent: new FormControl({ value: '', disabled: true }),
-    gateway: new FormControl({ value: '', disabled: true }),
-    hostname: new FormControl({ value: '', disabled: true }),
-    image: new FormControl({ value: '', disabled: true }),
-    ipv6_default_device: new FormControl({ value: '', disabled: true }),
-    next_server_v4: new FormControl({ value: '', disabled: true }),
-    next_server_v6: new FormControl({ value: '', disabled: true }),
-    filename: new FormControl({ value: '', disabled: true }),
-    power_address: new FormControl({ value: '', disabled: true }),
-    power_id: new FormControl({ value: '', disabled: true }),
-    power_pass: new FormControl({ value: '', disabled: true }),
-    power_type: new FormControl({ value: '', disabled: true }),
-    power_user: new FormControl({ value: '', disabled: true }),
-    power_options: new FormControl({ value: '', disabled: true }),
-    power_identity_file: new FormControl({ value: '', disabled: true }),
-    profile: new FormControl({ value: '', disabled: true }),
-    proxy: new FormControl({ value: '', disabled: true }),
-    server: new FormControl({ value: '', disabled: true }),
-    status: new FormControl({ value: '', disabled: true }),
-    virt_disk_driver: new FormControl({ value: '', disabled: true }),
-    virt_path: new FormControl({ value: '', disabled: true }),
-    virt_type: new FormControl({ value: '', disabled: true }),
-    boot_loaders: new FormControl({ value: [], disabled: true }),
-    boot_loaders_inherited: new FormControl({ value: false, disabled: true }),
-    ipv6_autoconfiguration: new FormControl({ value: false, disabled: true }),
-    repos_enabled: new FormControl({ value: false, disabled: true }),
-    netboot_enabled: new FormControl({ value: false, disabled: true }),
-    virt_auto_boot: new FormControl({ value: false, disabled: true }),
-    virt_pxe_boot: new FormControl({ value: false, disabled: true }),
-    owners: new FormControl({ value: [], disabled: true }),
-    owners_inherited: new FormControl({ value: false, disabled: true }),
-    boot_files: new FormControl({ value: new Map(), disabled: true }),
-    boot_files_inherited: new FormControl({ value: false, disabled: true }),
-    fetchable_files: new FormControl({ value: new Map(), disabled: true }),
-    fetchable_files_inherited: new FormControl({
-      value: false,
-      disabled: true,
-    }),
-    kernel_options: new FormControl({ value: new Map(), disabled: true }),
-    kernel_options_inherited: new FormControl({ value: false, disabled: true }),
-    kernel_options_post: new FormControl({ value: new Map(), disabled: true }),
-    kernel_options_post_inherited: new FormControl({
-      value: false,
-      disabled: true,
-    }),
-    mgmt_classes: new FormControl({ value: [], disabled: true }),
-    mgmt_classes_inherited: new FormControl({ value: false, disabled: true }),
-    mgmt_parameters: new FormControl({ value: new Map(), disabled: true }),
-    mgmt_parameters_inherited: new FormControl({
-      value: false,
-      disabled: true,
-    }),
-    template_files: new FormControl({ value: new Map(), disabled: true }),
-    template_files_inherited: new FormControl({ value: false, disabled: true }),
-    autoinstall_meta: new FormControl({ value: new Map(), disabled: true }),
-    autoinstall_meta_inherited: new FormControl({
-      value: false,
-      disabled: true,
-    }),
-    name_servers: new FormControl({ value: [], disabled: true }),
-    name_servers_search: new FormControl({ value: [], disabled: true }),
-  });
+  systemReadonlyFormGroup = this._formBuilder.group({});
+  systemFormGroup = this._formBuilder.group({});
   isEditMode: boolean = false;
 
   // Show disable netboot
@@ -148,43 +556,99 @@ export class SystemEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
+    this.systemReadonlyInputData.forEach((value) => {
+      this.systemReadonlyFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.systemReadonlyFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
+    this.systemEditableInputData.forEach((value) => {
+      this.systemFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        this.systemFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
   }
 
   ngOnInit(): void {
     this.refreshData();
     // Observables for inherited properties
-    this.systemFormGroup.controls.autoinstall_meta_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.systemFormGroup.controls.autoinstall_meta),
-    );
-    this.systemFormGroup.controls.boot_files_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.systemFormGroup.controls.boot_files),
-    );
-    this.systemFormGroup.controls.boot_loaders_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.systemFormGroup.controls.boot_loaders),
-    );
-    this.systemFormGroup.controls.fetchable_files_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.systemFormGroup.controls.fetchable_files),
-    );
-    this.systemFormGroup.controls.kernel_options_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.systemFormGroup.controls.kernel_options),
-    );
-    this.systemFormGroup.controls.kernel_options_post_inherited.valueChanges.subscribe(
-      this.getInheritObservable(
-        this.systemFormGroup.controls.kernel_options_post,
-      ),
-    );
-    this.systemFormGroup.controls.mgmt_classes_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.systemFormGroup.controls.mgmt_classes),
-    );
-    this.systemFormGroup.controls.mgmt_parameters_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.systemFormGroup.controls.mgmt_parameters),
-    );
-    this.systemFormGroup.controls.owners_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.systemFormGroup.controls.owners),
-    );
-    this.systemFormGroup.controls.template_files_inherited.valueChanges.subscribe(
-      this.getInheritObservable(this.systemFormGroup.controls.template_files),
-    );
+    this.systemFormGroup
+      .get('autoinstall_meta_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.systemFormGroup.get('autoinstall_meta')),
+      );
+    this.systemFormGroup
+      .get('boot_files_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.systemFormGroup.get('boot_files')),
+      );
+    this.systemFormGroup
+      .get('boot_loaders_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.systemFormGroup.get('boot_loaders')),
+      );
+    this.systemFormGroup
+      .get('fetchable_files_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.systemFormGroup.get('fetchable_files')),
+      );
+    this.systemFormGroup
+      .get('kernel_options_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.systemFormGroup.get('kernel_options')),
+      );
+    this.systemFormGroup
+      .get('kernel_options_post_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(
+          this.systemFormGroup.get('kernel_options_post'),
+        ),
+      );
+    this.systemFormGroup
+      .get('mgmt_classes_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.systemFormGroup.get('mgmt_classes')),
+      );
+    this.systemFormGroup
+      .get('mgmt_parameters_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.systemFormGroup.get('mgmt_parameters')),
+      );
+    this.systemFormGroup
+      .get('owners_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.systemFormGroup.get('owners')),
+      );
+    this.systemFormGroup
+      .get('template_files_inherited')
+      .valueChanges.subscribe(
+        this.getInheritObservable(this.systemFormGroup.get('template_files')),
+      );
     // Check if PXE just once is enabled
     this.checkSettingsPxeJustOne();
   }
@@ -225,7 +689,9 @@ export class SystemEditComponent implements OnInit, OnDestroy {
       });
   }
 
-  getInheritObservable(valueControl: FormControl): (value: boolean) => void {
+  getInheritObservable(
+    valueControl: AbstractControl,
+  ): (value: boolean) => void {
     return (value: boolean): void => {
       if (!this.isEditMode) {
         // If we are not in edit-mode we want to discard processing the event
@@ -246,254 +712,148 @@ export class SystemEditComponent implements OnInit, OnDestroy {
   refreshData(): void {
     this.cobblerApiService
       .get_system(this.name, false, false, this.userService.token)
-      .subscribe(
-        (value) => {
+      .subscribe({
+        next: (value) => {
           this.system = value;
-          this.systemReadonlyFormGroup.controls.name.setValue(this.system.name);
-          this.systemReadonlyFormGroup.controls.uid.setValue(this.system.uid);
-          this.systemReadonlyFormGroup.controls.mtime.setValue(
-            new Date(this.system.mtime * 1000).toString(),
+          this.systemReadonlyFormGroup.patchValue({
+            name: this.system.name,
+            uid: this.system.uid,
+            mtime: Utils.floatToDate(this.system.mtime).toString(),
+            ctime: Utils.floatToDate(this.system.ctime).toString(),
+            depth: this.system.depth,
+            is_subobject: this.system.is_subobject,
+          });
+          this.systemFormGroup.patchValue({
+            serial_device: this.system.serial_device,
+            serial_baud_rate: this.system.serial_baud_rate,
+            ipv6_autoconfiguration: this.system.ipv6_autoconfiguration,
+            repos_enabled: this.system.repos_enabled,
+            netboot_enabled: this.system.netboot_enabled,
+            virt_pxe_boot: this.system.virt_pxe_boot,
+            redhat_management_key: this.system.redhat_management_key,
+            autoinstall: this.system.autoinstall,
+            parent: this.system.parent,
+            gateway: this.system.gateway,
+            hostname: this.system.hostname,
+            image: this.system.image,
+            ipv6_default_device: this.system.ipv6_default_device,
+            next_server_v4: this.system.next_server_v4,
+            next_server_v6: this.system.next_server_v6,
+            filename: this.system.filename,
+            power_address: this.system.power_address,
+            power_id: this.system.power_id,
+            power_pass: this.system.power_pass,
+            power_type: this.system.power_type,
+            power_user: this.system.power_user,
+            power_options: this.system.power_options,
+            power_identity_file: this.system.power_identity_file,
+            profile: this.system.profile,
+            proxy: this.system.proxy,
+            server: this.system.server,
+            status: this.system.status,
+            virt_disk_driver: this.system.virt_disk_driver,
+            virt_path: this.system.virt_path,
+            virt_type: this.system.virt_type,
+            name_servers: this.system.name_servers,
+            name_servers_search: this.system.name_servers_search,
+          });
+          Utils.patchFormGroupInherited(
+            this.systemFormGroup,
+            this.system.virt_cpus,
+            'virt_cpus',
+            0,
           );
-          this.systemReadonlyFormGroup.controls.ctime.setValue(
-            new Date(this.system.ctime * 1000).toString(),
+          Utils.patchFormGroupInherited(
+            this.systemFormGroup,
+            this.system.virt_file_size,
+            'virt_file_size',
+            0,
           );
-          this.systemReadonlyFormGroup.controls.depth.setValue(
-            this.system.depth,
+          Utils.patchFormGroupInherited(
+            this.systemFormGroup,
+            this.system.virt_ram,
+            'virt_ram',
+            0,
           );
-          this.systemReadonlyFormGroup.controls.is_subobject.setValue(
-            this.system.is_subobject,
+          Utils.patchFormGroupInherited(
+            this.systemFormGroup,
+            this.system.virt_auto_boot,
+            'virt_auto_boot',
+            false,
           );
-          if (typeof this.system.virt_cpus !== 'string') {
-            this.systemFormGroup.controls.virt_cpus.setValue(
-              this.system.virt_cpus,
-            );
-          }
-          if (typeof this.system.virt_file_size !== 'string') {
-            this.systemFormGroup.controls.virt_file_size.setValue(
-              this.system.virt_file_size,
-            );
-          }
-          if (typeof this.system.virt_ram !== 'string') {
-            this.systemFormGroup.controls.virt_ram.setValue(
-              this.system.virt_ram,
-            );
-          }
-          this.systemFormGroup.controls.serial_device.setValue(
-            this.system.serial_device,
+          Utils.patchFormGroupInherited(
+            this.systemFormGroup,
+            this.system.boot_loaders,
+            'boot_loaders',
+            ['ipxe', 'grub', 'pxe'],
           );
-          this.systemFormGroup.controls.serial_baud_rate.setValue(
-            this.system.serial_baud_rate,
+          Utils.patchFormGroupInherited(
+            this.systemFormGroup,
+            this.system.owners,
+            'owners',
+            [],
           );
-          this.systemFormGroup.controls.ipv6_autoconfiguration.setValue(
-            this.system.ipv6_autoconfiguration,
+          Utils.patchFormGroupInherited(
+            this.systemFormGroup,
+            this.system.boot_files,
+            'boot_files',
+            new Map<string, any>(),
           );
-          this.systemFormGroup.controls.repos_enabled.setValue(
-            this.system.repos_enabled,
+          Utils.patchFormGroupInherited(
+            this.systemFormGroup,
+            this.system.fetchable_files,
+            'fetchable_files',
+            new Map<string, any>(),
           );
-          this.systemFormGroup.controls.netboot_enabled.setValue(
-            this.system.netboot_enabled,
+          Utils.patchFormGroupInherited(
+            this.systemFormGroup,
+            this.system.kernel_options,
+            'kernel_options',
+            new Map<string, any>(),
           );
-          if (typeof this.system.virt_auto_boot !== 'string') {
-            // TODO: Show inheritance if string
-            this.systemFormGroup.controls.virt_auto_boot.setValue(
-              this.system.virt_auto_boot,
-            );
-          }
-          this.systemFormGroup.controls.virt_pxe_boot.setValue(
-            this.system.virt_pxe_boot,
+          Utils.patchFormGroupInherited(
+            this.systemFormGroup,
+            this.system.kernel_options_post,
+            'kernel_options_post',
+            new Map<string, any>(),
           );
-          this.systemFormGroup.controls.redhat_management_key.setValue(
-            this.system.redhat_management_key,
+          Utils.patchFormGroupInherited(
+            this.systemFormGroup,
+            this.system.mgmt_classes,
+            'mgmt_classes',
+            [],
           );
-          this.systemFormGroup.controls.autoinstall.setValue(
-            this.system.autoinstall,
+          Utils.patchFormGroupInherited(
+            this.systemFormGroup,
+            this.system.mgmt_parameters,
+            'mgmt_parameters',
+            new Map<string, any>(),
           );
-          this.systemFormGroup.controls.parent.setValue(this.system.parent);
-          this.systemFormGroup.controls.gateway.setValue(this.system.gateway);
-          this.systemFormGroup.controls.hostname.setValue(this.system.hostname);
-          this.systemFormGroup.controls.image.setValue(this.system.image);
-          this.systemFormGroup.controls.ipv6_default_device.setValue(
-            this.system.ipv6_default_device,
+          Utils.patchFormGroupInherited(
+            this.systemFormGroup,
+            this.system.template_files,
+            'template_files',
+            new Map<string, any>(),
           );
-          this.systemFormGroup.controls.next_server_v4.setValue(
-            this.system.next_server_v4,
+          Utils.patchFormGroupInherited(
+            this.systemFormGroup,
+            this.system.autoinstall_meta,
+            'autoinstall_meta',
+            new Map<string, any>(),
           );
-          this.systemFormGroup.controls.next_server_v6.setValue(
-            this.system.next_server_v6,
-          );
-          this.systemFormGroup.controls.filename.setValue(this.system.filename);
-          this.systemFormGroup.controls.power_address.setValue(
-            this.system.power_address,
-          );
-          this.systemFormGroup.controls.power_id.setValue(this.system.power_id);
-          this.systemFormGroup.controls.power_pass.setValue(
-            this.system.power_pass,
-          );
-          this.systemFormGroup.controls.power_type.setValue(
-            this.system.power_type,
-          );
-          this.systemFormGroup.controls.power_user.setValue(
-            this.system.power_user,
-          );
-          this.systemFormGroup.controls.power_options.setValue(
-            this.system.power_options,
-          );
-          this.systemFormGroup.controls.power_identity_file.setValue(
-            this.system.power_identity_file,
-          );
-          this.systemFormGroup.controls.profile.setValue(this.system.profile);
-          this.systemFormGroup.controls.proxy.setValue(this.system.proxy);
-          this.systemFormGroup.controls.server.setValue(this.system.server);
-          this.systemFormGroup.controls.status.setValue(this.system.status);
-          this.systemFormGroup.controls.virt_disk_driver.setValue(
-            this.system.virt_disk_driver,
-          );
-          this.systemFormGroup.controls.virt_path.setValue(
-            this.system.virt_path,
-          );
-          this.systemFormGroup.controls.virt_type.setValue(
-            this.system.virt_type,
-          );
-          this.systemFormGroup.controls.name_servers.setValue(
-            this.system.name_servers,
-          );
-          this.systemFormGroup.controls.name_servers_search.setValue(
-            this.system.name_servers_search,
-          );
-          if (typeof this.system.boot_loaders === 'string') {
-            this.systemFormGroup.controls.boot_loaders_inherited.setValue(true);
-            this.systemFormGroup.controls.boot_loaders.setValue([
-              'ipxe',
-              'grub',
-              'pxe',
-            ]);
-          } else {
-            this.systemFormGroup.controls.boot_loaders_inherited.setValue(
-              false,
-            );
-            this.systemFormGroup.controls.boot_loaders.setValue(
-              this.system.boot_loaders,
-            );
-          }
-          if (typeof this.system.owners === 'string') {
-            this.systemFormGroup.controls.owners_inherited.setValue(true);
-            this.systemFormGroup.controls.owners.setValue([]);
-          } else {
-            this.systemFormGroup.controls.owners_inherited.setValue(false);
-            this.systemFormGroup.controls.owners.setValue(this.system.owners);
-          }
-          if (typeof this.system.boot_files === 'string') {
-            this.systemFormGroup.controls.boot_files_inherited.setValue(true);
-            this.systemFormGroup.controls.boot_files.setValue(new Map());
-          } else {
-            this.systemFormGroup.controls.boot_files_inherited.setValue(false);
-            this.systemFormGroup.controls.boot_files.setValue(
-              this.system.boot_files,
-            );
-          }
-          if (typeof this.system.fetchable_files === 'string') {
-            this.systemFormGroup.controls.fetchable_files_inherited.setValue(
-              true,
-            );
-          } else {
-            this.systemFormGroup.controls.fetchable_files_inherited.setValue(
-              false,
-            );
-            this.systemFormGroup.controls.fetchable_files.setValue(
-              this.system.fetchable_files,
-            );
-          }
-          if (typeof this.system.kernel_options === 'string') {
-            this.systemFormGroup.controls.kernel_options_inherited.setValue(
-              true,
-            );
-            this.systemFormGroup.controls.kernel_options.setValue(new Map());
-          } else {
-            this.systemFormGroup.controls.kernel_options_inherited.setValue(
-              false,
-            );
-            this.systemFormGroup.controls.kernel_options.setValue(
-              this.system.kernel_options,
-            );
-          }
-          if (typeof this.system.kernel_options_post === 'string') {
-            this.systemFormGroup.controls.kernel_options_post_inherited.setValue(
-              true,
-            );
-            this.systemFormGroup.controls.kernel_options_post.setValue(
-              new Map(),
-            );
-          } else {
-            this.systemFormGroup.controls.kernel_options_post_inherited.setValue(
-              false,
-            );
-            this.systemFormGroup.controls.kernel_options_post.setValue(
-              this.system.kernel_options_post,
-            );
-          }
-          if (typeof this.system.mgmt_classes === 'string') {
-            this.systemFormGroup.controls.mgmt_classes_inherited.setValue(true);
-            this.systemFormGroup.controls.mgmt_classes.setValue([]);
-          } else {
-            this.systemFormGroup.controls.mgmt_classes_inherited.setValue(
-              false,
-            );
-            this.systemFormGroup.controls.mgmt_classes.setValue(
-              this.system.mgmt_classes,
-            );
-          }
-          if (typeof this.system.mgmt_parameters === 'string') {
-            this.systemFormGroup.controls.mgmt_parameters_inherited.setValue(
-              true,
-            );
-            this.systemFormGroup.controls.mgmt_parameters.setValue(new Map());
-          } else {
-            this.systemFormGroup.controls.mgmt_parameters_inherited.setValue(
-              false,
-            );
-            this.systemFormGroup.controls.mgmt_parameters.setValue(
-              this.system.mgmt_parameters,
-            );
-          }
-          if (typeof this.system.template_files === 'string') {
-            this.systemFormGroup.controls.template_files_inherited.setValue(
-              true,
-            );
-            this.systemFormGroup.controls.template_files.setValue(new Map());
-          } else {
-            this.systemFormGroup.controls.template_files_inherited.setValue(
-              false,
-            );
-            this.systemFormGroup.controls.template_files.setValue(
-              this.system.template_files,
-            );
-          }
-          if (typeof this.system.autoinstall_meta === 'string') {
-            this.systemFormGroup.controls.autoinstall_meta_inherited.setValue(
-              true,
-            );
-            this.systemFormGroup.controls.autoinstall_meta.setValue(new Map());
-          } else {
-            this.systemFormGroup.controls.autoinstall_meta_inherited.setValue(
-              false,
-            );
-            this.systemFormGroup.controls.autoinstall_meta.setValue(
-              this.system.autoinstall_meta,
-            );
-          }
         },
-        (error) => {
+        error: (error) => {
           // HTML encode the error message since it originates from XML
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 
   removeSystem(): void {
     this.cobblerApiService
       .remove_system(this.name, this.userService.token, false)
-      .subscribe(
-        (value) => {
+      .subscribe({
+        next: (value) => {
           if (value) {
             this.router.navigate(['/items', 'system']);
           }
@@ -503,11 +863,11 @@ export class SystemEditComponent implements OnInit, OnDestroy {
             'Close',
           );
         },
-        (error) => {
+        error: (error) => {
           // HTML encode the error message since it originates from XML
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
-      );
+      });
   }
 
   editSystem(): void {
@@ -515,34 +875,34 @@ export class SystemEditComponent implements OnInit, OnDestroy {
     this.systemFormGroup.enable();
     // Inherit inputs
     if (typeof this.system.autoinstall_meta === 'string') {
-      this.systemFormGroup.controls.autoinstall_meta.disable();
+      this.systemFormGroup.get('autoinstall_meta').disable();
     }
     if (typeof this.system.boot_files === 'string') {
-      this.systemFormGroup.controls.boot_files.disable();
+      this.systemFormGroup.get('boot_files').disable();
     }
     if (typeof this.system.boot_loaders === 'string') {
-      this.systemFormGroup.controls.boot_loaders.disable();
+      this.systemFormGroup.get('boot_loaders').disable();
     }
     if (typeof this.system.fetchable_files === 'string') {
-      this.systemFormGroup.controls.fetchable_files.disable();
+      this.systemFormGroup.get('fetchable_files').disable();
     }
     if (typeof this.system.kernel_options === 'string') {
-      this.systemFormGroup.controls.kernel_options.disable();
+      this.systemFormGroup.get('kernel_options').disable();
     }
     if (typeof this.system.kernel_options_post === 'string') {
-      this.systemFormGroup.controls.kernel_options_post.disable();
+      this.systemFormGroup.get('kernel_options_post').disable();
     }
     if (typeof this.system.mgmt_classes === 'string') {
-      this.systemFormGroup.controls.mgmt_classes.disable();
+      this.systemFormGroup.get('mgmt_classes').disable();
     }
     if (typeof this.system.mgmt_parameters === 'string') {
-      this.systemFormGroup.controls.mgmt_parameters.disable();
+      this.systemFormGroup.get('mgmt_parameters').disable();
     }
     if (typeof this.system.owners === 'string') {
-      this.systemFormGroup.controls.owners.disable();
+      this.systemFormGroup.get('owners').disable();
     }
     if (typeof this.system.template_files === 'string') {
-      this.systemFormGroup.controls.template_files.disable();
+      this.systemFormGroup.get('template_files').disable();
     }
   }
 
@@ -568,7 +928,7 @@ export class SystemEditComponent implements OnInit, OnDestroy {
     this.cobblerApiService
       .get_system_as_rendered(this.system.name, this.userService.token)
       .subscribe((value) => {
-        const dialogRef = this.dialog.open(DialogBoxItemRenderedComponent, {
+        this.dialog.open(DialogBoxItemRenderedComponent, {
           data: {
             itemType: 'System',
             uid: this.system.uid,
@@ -602,7 +962,7 @@ export class SystemEditComponent implements OnInit, OnDestroy {
               .copy_system(systemHandle, newItemName, this.userService.token)
               .pipe(takeUntil(this.ngUnsubscribe))
               .subscribe({
-                next: (value) => {
+                next: () => {
                   this.router.navigate(['/items', 'system', newItemName]);
                 },
                 error: (error) => {
@@ -641,11 +1001,11 @@ export class SystemEditComponent implements OnInit, OnDestroy {
             );
           });
           combineLatest(modifyObservables).subscribe({
-            next: (value) => {
+            next: () => {
               this.cobblerApiService
                 .save_system(systemHandle, this.userService.token)
                 .subscribe({
-                  next: (value1) => {
+                  next: () => {
                     this.isEditMode = false;
                     this.systemFormGroup.disable();
                     this.refreshData();

--- a/projects/cobbler-frontend/src/app/items/system/edit/system-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/system/edit/system-edit.component.ts
@@ -25,6 +25,10 @@ import { MultiSelectComponent } from '../../../common/multi-select/multi-select.
 import { UserService } from '../../../services/user.service';
 import Utils, { CobblerInputChoices, CobblerInputData } from '../../../utils';
 import { DialogBoxItemRenderedComponent } from '../../../common/dialog-box-item-rendered/dialog-box-item-rendered.component';
+import {
+  cobblerItemEditableData,
+  cobblerItemReadonlyData,
+} from '../../metadata';
 
 @Component({
   selector: 'cobbler-edit',
@@ -54,63 +58,9 @@ export class SystemEditComponent implements OnInit, OnDestroy {
   private ngUnsubscribe = new Subject<void>();
 
   // Form data
-  systemReadonlyInputData: Array<CobblerInputData> = [
-    {
-      formControlName: 'name',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Name',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'uid',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'UID',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'mtime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Last modified time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'ctime',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Creation time',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-    {
-      formControlName: 'depth',
-      inputType: CobblerInputChoices.NUMBER,
-      label: 'Depth',
-      disabled: false,
-      readonly: true,
-      defaultValue: 0,
-      inherited: false,
-    },
-    {
-      formControlName: 'is_subobject',
-      inputType: CobblerInputChoices.CHECKBOX,
-      label: 'Is Subobject?',
-      disabled: false,
-      readonly: true,
-      defaultValue: '',
-      inherited: false,
-    },
-  ];
+  systemReadonlyInputData = cobblerItemReadonlyData;
   systemEditableInputData: Array<CobblerInputData> = [
+    ...cobblerItemEditableData,
     {
       formControlName: 'virt_cpus',
       inputType: CobblerInputChoices.NUMBER,
@@ -154,15 +104,6 @@ export class SystemEditComponent implements OnInit, OnDestroy {
       disabled: true,
       readonly: false,
       defaultValue: 0,
-      inherited: false,
-    },
-    {
-      formControlName: 'comment',
-      inputType: CobblerInputChoices.TEXT,
-      label: 'Comment',
-      disabled: true,
-      readonly: false,
-      defaultValue: '',
       inherited: false,
     },
     {

--- a/projects/cobbler-frontend/src/app/items/system/edit/system-edit.component.ts
+++ b/projects/cobbler-frontend/src/app/items/system/edit/system-edit.component.ts
@@ -2,7 +2,6 @@ import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
 import {
   AbstractControl,
   FormBuilder,
-  FormControl,
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
@@ -497,42 +496,12 @@ export class SystemEditComponent implements OnInit, OnDestroy {
     @Inject(MatDialog) readonly dialog: MatDialog,
   ) {
     this.name = this.route.snapshot.paramMap.get('name');
-    this.systemReadonlyInputData.forEach((value) => {
-      this.systemReadonlyFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.systemReadonlyFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
-    this.systemEditableInputData.forEach((value) => {
-      this.systemFormGroup.addControl(
-        value.formControlName,
-        new FormControl({
-          value: value.defaultValue,
-          disabled: value.disabled,
-        }),
-      );
-      if (value.inherited) {
-        this.systemFormGroup.addControl(
-          value.formControlName + '_inherited',
-          new FormControl({
-            value: false,
-            disabled: value.disabled,
-          }),
-        );
-      }
-    });
+    Utils.fillupItemFormGroup(
+      this.systemReadonlyFormGroup,
+      this.systemFormGroup,
+      this.systemReadonlyInputData,
+      this.systemEditableInputData,
+    );
   }
 
   ngOnInit(): void {

--- a/projects/cobbler-frontend/src/app/utils.ts
+++ b/projects/cobbler-frontend/src/app/utils.ts
@@ -1,4 +1,4 @@
-import { FormGroup } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 
 export enum CobblerInputChoices {
   TEXT = 'text',
@@ -84,5 +84,49 @@ export default class Utils {
         [`${attributeName}_inherited`]: false,
       });
     }
+  }
+
+  static fillupItemFormGroup(
+    readonlyFormGroup: FormGroup,
+    editableFormGroup: FormGroup,
+    readonlyMetadata: Array<CobblerInputData>,
+    editableMetadata: Array<CobblerInputData>,
+  ) {
+    readonlyMetadata.forEach((value) => {
+      readonlyFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        readonlyFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
+    editableMetadata.forEach((value) => {
+      editableFormGroup.addControl(
+        value.formControlName,
+        new FormControl({
+          value: value.defaultValue,
+          disabled: value.disabled,
+        }),
+      );
+      if (value.inherited) {
+        editableFormGroup.addControl(
+          value.formControlName + '_inherited',
+          new FormControl({
+            value: false,
+            disabled: value.disabled,
+          }),
+        );
+      }
+    });
   }
 }

--- a/projects/cobbler-frontend/src/app/utils.ts
+++ b/projects/cobbler-frontend/src/app/utils.ts
@@ -1,5 +1,23 @@
 import { FormGroup } from '@angular/forms';
 
+export enum CobblerInputChoices {
+  TEXT = 'text',
+  NUMBER = 'number',
+  CHECKBOX = 'checkbox',
+  MULTI_SELECT = 'multi-select',
+  KEY_VALUE = 'key-value',
+}
+
+export interface CobblerInputData {
+  formControlName: string;
+  inputType: CobblerInputChoices;
+  label: string;
+  disabled: boolean;
+  readonly: boolean;
+  defaultValue: any;
+  inherited: boolean;
+}
+
 export default class Utils {
   static toHTML(input: string): any {
     return new DOMParser().parseFromString(input, 'text/html').documentElement
@@ -46,5 +64,25 @@ export default class Utils {
 
   static floatToDate(value: number): Date {
     return new Date(value * 1000);
+  }
+
+  // Method to patch a FormGroup for an inherited attribute. This is used on the item details pages.
+  static patchFormGroupInherited<Type>(
+    formGroup: FormGroup,
+    attribute: Type | string,
+    attributeName: string,
+    defaultValue: Type,
+  ): void {
+    if (typeof attribute === 'string') {
+      formGroup.patchValue({
+        [`${attributeName}`]: defaultValue,
+        [`${attributeName}_inherited`]: true,
+      });
+    } else {
+      formGroup.patchValue({
+        [`${attributeName}`]: attribute,
+        [`${attributeName}_inherited`]: false,
+      });
+    }
   }
 }


### PR DESCRIPTION
Fixes #279 

This doesn't introduce a custom component but it does deduplicate the effort of copy-pasting all the elements. As the data models rarely change this should be an acceptable compromise.