### PR TITLE
Switch to non-privileged container image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ Thumbs.db
 *.css.map
 *.sass.map
 *.scss.map
+
+# Codacy AI rules
+/.github/instructions/codacy.instructions.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,15 @@ RUN npm install -g @angular/cli
 WORKDIR /app
 COPY . /app
 RUN npm install \
-  && ng build "typescript-xmlrpc" --configuration $CONFIGURATION \
-  && ng build "cobbler-api" --configuration $CONFIGURATION \
-  && ng build "cobbler-frontend" --configuration $CONFIGURATION
+  && ng build "typescript-xmlrpc" --configuration=$CONFIGURATION \
+  && ng build "cobbler-api" --configuration=$CONFIGURATION \
+  && ng build "cobbler-frontend" --configuration=$CONFIGURATION
 
-FROM docker.io/library/nginx:1.31-alpine
+FROM docker.io/nginxinc/nginx-unprivileged:1.31-alpine
 WORKDIR /usr/share/nginx/html
+USER 0
+RUN ["rm", "index.html", "50x.html"]
+USER $UID
 COPY --from=builder /app/docker/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/docker/*.sh /docker-entrypoint.d/
-COPY --from=builder /app/dist/cobbler-frontend /usr/share/nginx/html
-
+COPY --from=builder /app/dist/cobbler-frontend/browser /usr/share/nginx/html

--- a/docker/default.conf
+++ b/docker/default.conf
@@ -1,5 +1,5 @@
 server {
-    listen       80;
+    listen       8080;
     server_name  localhost;
 
     # set the root directory for the server (we need to copy our

--- a/docs-additonal/deployment.md
+++ b/docs-additonal/deployment.md
@@ -8,16 +8,30 @@ TBD
 
 ## Docker / Podman
 
+The container runs as an unprivileged user (UID 101) and listens on port 8080.
+
 With Docker:
 
 ```
-docker run -d -p 8080:80 ghcr.io/cobbler/cobbler-web:main
+docker run -d -p 8080:8080 ghcr.io/cobbler/cobbler-web:main
 ```
 
 With Podman:
 
 ```
-podman run -d -p 8080:80 ghcr.io/cobbler/cobbler-web:main
+podman run -d -p 8080:8080 ghcr.io/cobbler/cobbler-web:main
+```
+
+### Running with Read-Only Filesystem
+
+For enhanced security, the container supports running with a read-only filesystem:
+
+```
+podman run -d -p 8080:8080 \
+  --read-only \
+  --tmpfs /tmp:rw,noexec,nosuid,size=64m \
+  --tmpfs /var/cache/nginx:rw,noexec,nosuid,size=64m \
+  ghcr.io/cobbler/cobbler-web:main
 ```
 
 ## Helm Chart
@@ -49,7 +63,9 @@ with multiple URLs. To change the used URL, please log out of the Web UI and log
 Example for Docker/Podman:
 
 ```shell
-podman run -d -p 8080:80 -v $(pwd)/app-config.json:/config/app-config.json:ro ghcr.io/cobbler/cobbler-web:<tag>
+podman run -d -p 8080:8080 \
+  -v $(pwd)/app-config.json:/config/app-config.json:ro \
+  ghcr.io/cobbler/cobbler-web:<tag>
 ```
 
 Example for Helm:

--- a/projects/cobbler-frontend/src/app/actions/check-sys/check-sys.component.ts
+++ b/projects/cobbler-frontend/src/app/actions/check-sys/check-sys.component.ts
@@ -1,11 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnDestroy, OnInit, inject } from '@angular/core';
-import { MatButton, MatIconButton } from '@angular/material/button';
+import { MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatTooltip } from '@angular/material/tooltip';
 import { RouterOutlet } from '@angular/router';
 import { CobblerApiService } from 'cobbler-api';
 import { Observable, of, Subject } from 'rxjs';
@@ -21,10 +20,8 @@ import Utils from '../../utils';
     RouterOutlet,
     MatListModule,
     CommonModule,
-    MatButton,
     MatIconButton,
     MatIcon,
-    MatTooltip,
     MatProgressSpinner,
   ],
 })

--- a/projects/cobbler-frontend/src/app/actions/repo-sync/repo-sync.component.ts
+++ b/projects/cobbler-frontend/src/app/actions/repo-sync/repo-sync.component.ts
@@ -1,6 +1,5 @@
 import { Component, inject, OnDestroy } from '@angular/core';
 import { MatListModule } from '@angular/material/list';
-import { RouterOutlet } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { UserService } from '../../services/user.service';
@@ -34,7 +33,6 @@ import Utils from '../../utils';
   templateUrl: './repo-sync.component.html',
   styleUrls: ['./repo-sync.component.css'],
   imports: [
-    RouterOutlet,
     MatListModule,
     MatButton,
     FormsModule,

--- a/projects/cobbler-frontend/src/app/actions/sync/sync.component.ts
+++ b/projects/cobbler-frontend/src/app/actions/sync/sync.component.ts
@@ -14,7 +14,6 @@ import {
 } from '@angular/forms';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
-import { MatDialogClose } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
 import {
   MatFormField,
@@ -37,7 +36,6 @@ import Utils from '../../utils';
   imports: [
     RouterOutlet,
     MatButton,
-    MatDialogClose,
     ReactiveFormsModule,
     MatCheckbox,
     MatInput,

--- a/projects/cobbler-frontend/src/app/common/multi-select/multi-select.component.ts
+++ b/projects/cobbler-frontend/src/app/common/multi-select/multi-select.component.ts
@@ -1,4 +1,3 @@
-import { AsyncPipe } from '@angular/common';
 import { Component, inject, Input } from '@angular/core';
 import {
   AbstractControl,
@@ -31,7 +30,6 @@ import { DialogTextInputComponent } from '../dialog-text-input/dialog-text-input
     MatFormFieldModule,
     MatSelectModule,
     ReactiveFormsModule,
-    AsyncPipe,
     MatListModule,
     MatCheckboxModule,
     MatButtonModule,

--- a/projects/cobbler-frontend/src/app/signatures/signatures.component.ts
+++ b/projects/cobbler-frontend/src/app/signatures/signatures.component.ts
@@ -1,7 +1,4 @@
-import { AsyncPipe } from '@angular/common';
 import { Component, OnDestroy, OnInit, inject } from '@angular/core';
-import { MatDivider } from '@angular/material/divider';
-import { MatList, MatListItem } from '@angular/material/list';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import {
@@ -75,10 +72,6 @@ interface OsBreedFlatNode {
     MatCellDef,
     MatHeaderRowDef,
     MatRowDef,
-    MatDivider,
-    AsyncPipe,
-    MatList,
-    MatListItem,
     MatProgressSpinner,
   ],
   templateUrl: './signatures.component.html',


### PR DESCRIPTION
Fixes #556

This PR switches the production container images to a rootless and read-only approach.