### PR TITLE
Side navigation: Improve UX

### DIFF
--- a/projects/cobbler-frontend/src/app/manage-menu/manage-menu.component.css
+++ b/projects/cobbler-frontend/src/app/manage-menu/manage-menu.component.css
@@ -1,3 +1,65 @@
 .content {
   margin: 32px;
 }
+
+/* Scrollbar on the right */
+.sidenav {
+  padding: 0 0px 25px 0px;
+}
+
+.logo {
+  margin-left: 5px;
+}
+
+/* Icon alignment */
+::ng-deep .nav-link .mat-mdc-list-item-unscoped-content {
+  display: flex;
+  align-items: center;
+}
+
+.sidenav-icon {
+  font-size: 18px;
+  width: 25px;
+  height: 25px;
+  padding-right: 3px;
+}
+
+.divider {
+  padding: 15px 0 0 0;
+}
+
+h2 {
+  margin-bottom: 5px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+}
+
+.close-btn mat-icon {
+  font-size: 18px;
+  width: 20px;
+  height: 20px;
+}
+
+.close-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  height: fit-content;
+  margin-left: auto;
+}
+
+/* Side padding for the sidenav */
+.mat-mdc-nav-list {
+  padding-left: 25px;
+  padding-right: 25px;
+}
+
+/* Header alignment */
+mat-toolbar,
+.mat-mdc-toolbar-row {
+  padding: 0 0 0 10px;
+}

--- a/projects/cobbler-frontend/src/app/manage-menu/manage-menu.component.html
+++ b/projects/cobbler-frontend/src/app/manage-menu/manage-menu.component.html
@@ -1,8 +1,21 @@
 <mat-sidenav-container class="full-height">
-  <mat-sidenav #sidenav mode="over">
-    <mat-toolbar>
-      <mat-toolbar-row>
-        <h2>Cobbler</h2>
+  <mat-sidenav #sidenav mode="over" class="sidenav">
+    <mat-toolbar class="header">
+      <mat-toolbar-row class="row">
+        <mat-icon
+          class="align-center"
+          svgIcon="cobbler-logo"
+          aria-hidden="true"
+        ></mat-icon>
+        <h2 class="logo">Cobbler</h2>
+        <button
+          mat-icon-button
+          (click)="sidenav.close()"
+          class="close-btn"
+          aria-label="Close sidenav"
+        >
+          <mat-icon class="close-icon" aria-hidden="true">close</mat-icon>
+        </button>
       </mat-toolbar-row>
     </mat-toolbar>
 
@@ -16,7 +29,7 @@
         [routerLinkActive]="'is-active'"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#187;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">start</mat-icon>
         Distros
       </a>
       <a
@@ -27,7 +40,7 @@
         [routerLinkActive]="'is-active'"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#187;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">group</mat-icon>
         Profiles
       </a>
       <a
@@ -38,7 +51,9 @@
         [routerLinkActive]="'is-active'"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#187;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true"
+          >account_tree</mat-icon
+        >
         Systems
       </a>
       <a
@@ -49,7 +64,9 @@
         [routerLinkActive]="'is-active'"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#187;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true"
+          >folder_managed</mat-icon
+        >
         Repos
       </a>
       <a
@@ -60,7 +77,7 @@
         [routerLinkActive]="'is-active'"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#187;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">album</mat-icon>
         Images
       </a>
       <a
@@ -71,7 +88,7 @@
         [routerLinkActive]="'is-active'"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#187;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">description</mat-icon>
         Templates
       </a>
       <a
@@ -82,7 +99,7 @@
         [routerLinkActive]="'is-active'"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#187;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">code</mat-icon>
         Snippets
       </a>
       <a
@@ -93,7 +110,9 @@
         [routerLinkActive]="'is-active'"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#187;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true"
+          >dashboard_2_edit</mat-icon
+        >
         Management Classes
       </a>
       <a
@@ -104,7 +123,7 @@
         [routerLinkActive]="'is-active'"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#187;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">menu_open</mat-icon>
         Menus
       </a>
       <a
@@ -115,10 +134,10 @@
         [routerLinkActive]="'is-active'"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#187;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">settings</mat-icon>
         Settings
       </a>
-      <mat-divider></mat-divider>
+      <mat-divider class="divider"></mat-divider>
       <h2 matSubheader>Resources</h2>
       <a
         mat-list-item
@@ -127,7 +146,7 @@
         [routerLinkActive]="'is-active'"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#8620;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">package_2</mat-icon>
         Packages
       </a>
       <a
@@ -137,10 +156,10 @@
         [routerLinkActive]="'is-active'"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#8620;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">draft</mat-icon>
         Files
       </a>
-      <mat-divider></mat-divider>
+      <mat-divider class="divider"></mat-divider>
       <h2 matSubheader>Actions</h2>
       <a
         mat-list-item
@@ -148,7 +167,7 @@
         [routerLink]="['/actions', 'import']"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#9881;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">album</mat-icon>
         Import DVD
       </a>
       <a
@@ -157,7 +176,7 @@
         [routerLink]="['/actions', 'sync']"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#9881;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">sync</mat-icon>
         Sync
       </a>
       <a
@@ -165,7 +184,8 @@
         class="nav-link"
         [routerLink]="['/actions', 'reposync']"
         (click)="sidenav.close()"
-        ><b class="symbol">&#9881;</b>
+      >
+        <mat-icon class="sidenav-icon" aria-hidden="true">folder_data</mat-icon>
         Reposync
       </a>
       <a
@@ -173,7 +193,8 @@
         class="nav-link"
         [routerLink]="['/actions', 'buildiso']"
         (click)="sidenav.close()"
-        ><b class="symbol">&#9881;</b>
+      >
+        <mat-icon class="sidenav-icon" aria-hidden="true">album</mat-icon>
         Build ISO
       </a>
       <a
@@ -182,7 +203,7 @@
         [routerLink]="['/actions', 'hardlink']"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#9881;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">link_2</mat-icon>
         Hardlink
       </a>
       <a
@@ -191,7 +212,7 @@
         [routerLink]="['/actions', 'mkloaders']"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#9881;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">start</mat-icon>
         Mkloaders
       </a>
       <a
@@ -200,7 +221,7 @@
         [routerLink]="['/actions', 'validate-autoinstalls']"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#9881;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">fact_check</mat-icon>
         Validate Autoinstalls
       </a>
       <a
@@ -209,10 +230,10 @@
         [routerLink]="['/actions', 'replicate']"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#9881;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">file_copy</mat-icon>
         Replicate
       </a>
-      <mat-divider></mat-divider>
+      <mat-divider class="divider"></mat-divider>
       <h2 matSubheader>Cobbler</h2>
       <a
         mat-list-item
@@ -220,7 +241,7 @@
         [routerLink]="['/actions', 'check']"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#8646;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">refresh</mat-icon>
         Check
       </a>
       <a
@@ -229,7 +250,7 @@
         [routerLink]="['/actions', 'status']"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#8646;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">bar_chart</mat-icon>
         Status
       </a>
       <a
@@ -238,7 +259,9 @@
         [routerLink]="['/events']"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#8646;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true"
+          >calendar_month</mat-icon
+        >
         Events
       </a>
       <a
@@ -247,7 +270,7 @@
         [routerLink]="['/signatures']"
         (click)="sidenav.close()"
       >
-        <b class="symbol">&#8646;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">ink_pen</mat-icon>
         Signatures
       </a>
       <a
@@ -256,7 +279,9 @@
         href="https://cobbler.readthedocs.io/en/latest/"
         target="_blank"
       >
-        <b class="symbol">&#8646;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true"
+          >article_person</mat-icon
+        >
         Documentation
       </a>
       <a
@@ -265,10 +290,10 @@
         href="https://gitter.im/cobbler/community"
         target="_blank"
       >
-        <b class="symbol">&#8646;</b>
+        <mat-icon class="sidenav-icon" aria-hidden="true">live_help</mat-icon>
         Online Help Chat
       </a>
-      <mat-divider></mat-divider>
+      <mat-divider class="divider"></mat-divider>
     </mat-nav-list>
   </mat-sidenav>
 

--- a/projects/cobbler-frontend/src/app/manage-menu/manage-menu.component.html
+++ b/projects/cobbler-frontend/src/app/manage-menu/manage-menu.component.html
@@ -5,7 +5,8 @@
         <mat-icon
           class="align-center"
           svgIcon="cobbler-logo"
-          aria-hidden="true"
+          aria-hidden="false"
+          aria-label="Cobbler Logo"
         ></mat-icon>
         <h2 class="logo">Cobbler</h2>
         <button
@@ -29,7 +30,7 @@
         [routerLinkActive]="'is-active'"
         (click)="sidenav.close()"
       >
-        <mat-icon class="sidenav-icon" aria-hidden="true">start</mat-icon>
+        <mat-icon class="sidenav-icon" aria-hidden="true">android</mat-icon>
         Distros
       </a>
       <a

--- a/projects/cobbler-frontend/src/app/manage-menu/manage-menu.component.ts
+++ b/projects/cobbler-frontend/src/app/manage-menu/manage-menu.component.ts
@@ -6,6 +6,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { Router, RouterModule, RouterOutlet } from '@angular/router';
 import { NavbarComponent } from '../navbar/navbar.component';
 import { MatIconModule } from '@angular/material/icon';
+import { MatAnchor, MatButtonModule } from '@angular/material/button';
 
 @Component({
   selector: 'cobbler-manage-menu',
@@ -21,6 +22,7 @@ import { MatIconModule } from '@angular/material/icon';
     NavbarComponent,
     MatListModule,
     MatIconModule,
+    MatButtonModule,
   ],
 })
 export class ManageMenuComponent {

--- a/projects/cobbler-frontend/src/app/navbar/navbar.component.css
+++ b/projects/cobbler-frontend/src/app/navbar/navbar.component.css
@@ -15,3 +15,10 @@ a {
   color: inherit;
   text-decoration: inherit;
 }
+
+/* profile icon */
+.profile {
+  font-size: 22px;
+  width: 30px;
+  height: 30px;
+}

--- a/projects/cobbler-frontend/src/app/navbar/navbar.component.html
+++ b/projects/cobbler-frontend/src/app/navbar/navbar.component.html
@@ -22,11 +22,11 @@
   <div>
     @if (islogged) {
       <button mat-button [matMenuTriggerFor]="profileMenu">
-        <mat-icon>account_circle</mat-icon> {{ authO.username }}
+        <mat-icon class="profile">account_circle</mat-icon> {{ authO.username }}
       </button>
     } @else {
       <button mat-icon-button [matMenuTriggerFor]="profileMenu">
-        <mat-icon>account_circle</mat-icon>
+        <mat-icon class="profile">account_circle</mat-icon>
       </button>
     }
     <mat-menu #profileMenu="matMenu">

--- a/projects/cobbler-frontend/src/index.html
+++ b/projects/cobbler-frontend/src/index.html
@@ -17,7 +17,7 @@
       rel="stylesheet"
     />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
       rel="stylesheet"
     />
     <link

--- a/projects/cobbler-frontend/src/styles.scss
+++ b/projects/cobbler-frontend/src/styles.scss
@@ -12,3 +12,7 @@ body {
   width: 100%;
   height: 100%;
 }
+
+.mat-mdc-icon, .material-icons {
+  font-family: 'Material Symbols Outlined' !important;
+}

--- a/projects/cobbler-frontend/src/styles.scss
+++ b/projects/cobbler-frontend/src/styles.scss
@@ -13,6 +13,7 @@ body {
   height: 100%;
 }
 
-.mat-mdc-icon, .material-icons {
-  font-family: 'Material Symbols Outlined' !important;
+.mat-mdc-icon,
+.material-icons {
+  font-family: "Material Symbols Outlined" !important;
 }


### PR DESCRIPTION
This PR improves the overall look of the side navigation. It adds icons for better navigation and padding. 

Closes #374 

<img width="275" height="666" alt="image" src="https://github.com/user-attachments/assets/56d912bf-4f48-40ab-81f5-0bd8990f7719" />
