### PR TITLE
Items: Add filtering to data tables

### DIFF
--- a/projects/cobbler-frontend/src/app/app-events/app-events.component.css
+++ b/projects/cobbler-frontend/src/app/app-events/app-events.component.css
@@ -1,3 +1,8 @@
 table {
   width: 100%;
 }
+
+.filter-container {
+  display: flex;
+  gap: 10px;
+}

--- a/projects/cobbler-frontend/src/app/app-events/app-events.component.html
+++ b/projects/cobbler-frontend/src/app/app-events/app-events.component.html
@@ -3,6 +3,43 @@
   <div class="AppEvents-div">
     <h1 class="title">EVENTS</h1>
 
+    <div class="filter-container">
+      <!-- Select name -->
+      <mat-form-field appearance="fill">
+        <mat-label>Name</mat-label>
+        <mat-select (selectionChange)="applyFilter()" #nameSelect>
+          <mat-option value="">All names</mat-option>
+          @for (name of cobblerEventsNames; track name) {
+            <mat-option [value]="name">{{ name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+      <!-- Select state -->
+      <mat-form-field appearance="fill">
+        <mat-label>State</mat-label>
+        <mat-select (selectionChange)="applyFilter()" #stateSelect>
+          <mat-option value="">All states</mat-option>
+          @for (element of cobblerEvents.data; track element.id) {
+            <mat-option [value]="element.state">{{ element.state }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+      <!-- Select date -->
+      <mat-form-field appearance="fill">
+        <mat-label>Date</mat-label>
+        <input
+          matInput
+          [matDatepicker]="picker"
+          (dateChange)="applyFilter()"
+          #dateInput
+        />
+        <mat-datepicker-toggle matIconSuffix [for]="picker">
+          <mat-icon matDatepickerToggleIcon>keyboard_arrow_down</mat-icon>
+        </mat-datepicker-toggle>
+        <mat-datepicker #picker></mat-datepicker>
+      </mat-form-field>
+    </div>
+
     <table mat-table [dataSource]="cobblerEvents">
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef>Name</th>

--- a/projects/cobbler-frontend/src/app/app-events/app-events.component.ts
+++ b/projects/cobbler-frontend/src/app/app-events/app-events.component.ts
@@ -2,6 +2,7 @@ import { CommonModule, DatePipe } from '@angular/common';
 import {
   AfterViewInit,
   Component,
+  ElementRef,
   OnDestroy,
   OnInit,
   ViewChild,
@@ -19,11 +20,18 @@ import { DialogBoxTextConfirmComponent } from '../common/dialog-box-text-confirm
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatSort } from '@angular/material/sort';
+import { MatSelect, MatSelectModule } from '@angular/material/select';
+import { provideNativeDateAdapter } from '@angular/material/core';
 
 @Component({
   selector: 'cobbler-app-events',
   templateUrl: './app-events.component.html',
   styleUrls: ['./app-events.component.css'],
+  providers: [provideNativeDateAdapter()],
   imports: [
     RouterOutlet,
     MatListModule,
@@ -34,6 +42,10 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
     DatePipe,
     CommonModule,
     MatPaginatorModule,
+    MatInputModule,
+    MatFormFieldModule,
+    MatDatepickerModule,
+    MatSelectModule,
   ],
 })
 export class AppEventsComponent implements OnInit, OnDestroy, AfterViewInit {
@@ -52,8 +64,13 @@ export class AppEventsComponent implements OnInit, OnDestroy, AfterViewInit {
     'actions',
   ];
   cobblerEvents = new MatTableDataSource<Event>([]);
+  cobblerEventsNames: string[] = ['Loading items', 'Replicate'];
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+  @ViewChild('nameSelect') nameSelect!: MatSelect;
+  @ViewChild('stateSelect') stateSelect!: MatSelect;
+  @ViewChild('dateInput') dateInput!: ElementRef<HTMLInputElement>;
 
   ngOnInit(): void {
     this.cobblerApiService
@@ -62,15 +79,58 @@ export class AppEventsComponent implements OnInit, OnDestroy, AfterViewInit {
       .subscribe((value: Array<Event>) => {
         this.cobblerEvents.data = value;
       });
+
+    // Custom predicate to be able to filter events data table by different parameters
+    this.cobblerEvents.filterPredicate = (
+      data: Event,
+      filter: string,
+    ): boolean => {
+      const searchTerms = JSON.parse(filter);
+
+      // Validate selected name
+      const matchesName = data.name
+        ? data.name.toLowerCase().includes(searchTerms.name.toLowerCase())
+        : true;
+
+      // Validate selected state
+      const matchesState = searchTerms.state
+        ? data.state === searchTerms.state
+        : true;
+
+      // Validate selected date
+      let matchesDate = true;
+      if (searchTerms.date) {
+        const filterDate = new Date(searchTerms.date).setHours(0, 0, 0, 0);
+        const eventDate = new Date(data.statetime * 1000).setHours(0, 0, 0, 0);
+        matchesDate = eventDate === filterDate;
+      }
+
+      return matchesName && matchesState && matchesDate;
+    };
   }
 
   ngAfterViewInit(): void {
     this.cobblerEvents.paginator = this.paginator;
+    this.cobblerEvents.sort = this.sort;
   }
 
   ngOnDestroy() {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  applyFilter() {
+    const filterValues = {
+      name: this.nameSelect?.value || '',
+      state: this.stateSelect?.value || '',
+      date: this.dateInput.nativeElement.value || '',
+    };
+
+    this.cobblerEvents.filter = JSON.stringify(filterValues);
+
+    if (this.cobblerEvents.paginator) {
+      this.cobblerEvents.paginator.firstPage();
+    }
   }
 
   showLogs(eventId: string, name: string) {

--- a/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.html
@@ -12,8 +12,16 @@
     >
   </div>
 </div>
-
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<mat-form-field appearance="fill">
+  <mat-label>Filter</mat-label>
+  <input
+    matInput
+    (keyup)="applyFilter($event)"
+    placeholder="Ex. aarch64:SLE-Micro-5.2-GM"
+    #input
+  />
+</mat-form-field>
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8" matSort>
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>

--- a/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.ts
@@ -27,6 +27,9 @@ import { UserService } from '../../../services/user.service';
 import Utils from '../../../utils';
 import { DistroCreateComponent } from '../create/distro-create.component';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSort } from '@angular/material/sort';
+import { MatInputModule } from '@angular/material/input';
 
 @Component({
   selector: 'cobbler-distro-overview',
@@ -39,6 +42,9 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
     MatMenuModule,
     MatTooltipModule,
     MatPaginatorModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSort,
   ],
 })
 export class DistrosOverviewComponent
@@ -59,6 +65,7 @@ export class DistrosOverviewComponent
 
   @ViewChild(MatTable) table: MatTable<Distro>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
 
   ngOnInit(): void {
     this.retrieveDistros();
@@ -66,11 +73,21 @@ export class DistrosOverviewComponent
 
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
   }
 
   ngOnDestroy(): void {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
   }
 
   private retrieveDistros(): void {

--- a/projects/cobbler-frontend/src/app/items/file/overview/file-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/file/overview/file-overview.component.html
@@ -8,8 +8,16 @@
     >
   </div>
 </div>
-
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<mat-form-field appearance="fill">
+  <mat-label>Filter</mat-label>
+  <input
+    matInput
+    (keyup)="applyFilter($event)"
+    placeholder="Ex. download_config_files_deb"
+    #input
+  />
+</mat-form-field>
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8" matSort>
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>

--- a/projects/cobbler-frontend/src/app/items/file/overview/file-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/file/overview/file-overview.component.ts
@@ -34,6 +34,9 @@ import { UserService } from '../../../services/user.service';
 import Utils from '../../../utils';
 import { FileCreateComponent } from '../create/file-create.component';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSort } from '@angular/material/sort';
 
 @Component({
   selector: 'cobbler-file-overview',
@@ -55,6 +58,9 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
     MatHeaderCellDef,
     MatTooltip,
     MatPaginatorModule,
+    MatInputModule,
+    MatFormFieldModule,
+    MatSort,
   ],
   templateUrl: './file-overview.component.html',
   styleUrl: './file-overview.component.scss',
@@ -75,6 +81,7 @@ export class FileOverviewComponent implements OnInit, OnDestroy, AfterViewInit {
 
   @ViewChild(MatTable) table: MatTable<File>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
 
   ngOnInit(): void {
     this.retrieveFiles();
@@ -82,11 +89,21 @@ export class FileOverviewComponent implements OnInit, OnDestroy, AfterViewInit {
 
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
   }
 
   ngOnDestroy(): void {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
   }
 
   private retrieveFiles(): void {

--- a/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.html
@@ -8,8 +8,16 @@
     >
   </div>
 </div>
-
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<mat-form-field appearance="fill">
+  <mat-label>Filter</mat-label>
+  <input
+    matInput
+    (keyup)="applyFilter($event)"
+    placeholder="Ex. s390x:SLE-Micro-5.1-GM:install-auto"
+    #input
+  />
+</mat-form-field>
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8" matSort>
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>

--- a/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.ts
@@ -26,6 +26,9 @@ import { UserService } from '../../../services/user.service';
 import Utils from '../../../utils';
 import { ImageCreateComponent } from '../create/image-create.component';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
 
 @Component({
   selector: 'cobbler-image-overview',
@@ -36,6 +39,9 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
     MatMenuModule,
     MatTooltipModule,
     MatPaginatorModule,
+    MatSort,
+    MatInputModule,
+    MatFormFieldModule,
   ],
   templateUrl: './image-overview.component.html',
   styleUrl: './image-overview.component.scss',
@@ -64,6 +70,7 @@ export class ImageOverviewComponent
 
   @ViewChild(MatTable) table: MatTable<Image>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
 
   ngOnInit(): void {
     this.retrieveImages();
@@ -71,11 +78,21 @@ export class ImageOverviewComponent
 
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
   }
 
   ngOnDestroy(): void {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
   }
 
   private retrieveImages(): void {

--- a/projects/cobbler-frontend/src/app/items/management-class/overview/management-class-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/management-class/overview/management-class-overview.component.html
@@ -12,8 +12,16 @@
     >
   </div>
 </div>
-
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<mat-form-field appearance="fill">
+  <mat-label>Filter</mat-label>
+  <input
+    matInput
+    (keyup)="applyFilter($event)"
+    placeholder="Ex. addons.xml"
+    #input
+  />
+</mat-form-field>
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8" matSort>
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>

--- a/projects/cobbler-frontend/src/app/items/management-class/overview/management-class-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/management-class/overview/management-class-overview.component.ts
@@ -26,6 +26,9 @@ import { UserService } from '../../../services/user.service';
 import Utils from '../../../utils';
 import { ManagementClassCreateComponent } from '../create/management-class-create.component';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
 
 @Component({
   selector: 'cobbler-management-class-overview',
@@ -36,6 +39,9 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
     MatMenuModule,
     MatTooltipModule,
     MatPaginatorModule,
+    MatSort,
+    MatInputModule,
+    MatFormFieldModule,
   ],
   templateUrl: './management-class-overview.component.html',
   styleUrl: './management-class-overview.component.scss',
@@ -63,6 +69,7 @@ export class ManagementClassOverviewComponent
 
   @ViewChild(MatTable) table: MatTable<Mgmgtclass>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
 
   ngOnInit(): void {
     this.retrieveManagementClasses();
@@ -70,11 +77,21 @@ export class ManagementClassOverviewComponent
 
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
   }
 
   ngOnDestroy(): void {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
   }
 
   private retrieveManagementClasses(): void {

--- a/projects/cobbler-frontend/src/app/items/menu/overview/menu-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/menu/overview/menu-overview.component.html
@@ -8,8 +8,16 @@
     >
   </div>
 </div>
-
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<mat-form-field appearance="fill">
+  <mat-label>Filter</mat-label>
+  <input
+    matInput
+    (keyup)="applyFilter($event)"
+    placeholder="Ex. cobbler_register"
+    #input
+  />
+</mat-form-field>
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8" matSort>
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>

--- a/projects/cobbler-frontend/src/app/items/menu/overview/menu-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/menu/overview/menu-overview.component.ts
@@ -26,6 +26,9 @@ import { UserService } from '../../../services/user.service';
 import Utils from '../../../utils';
 import { MenuCreateComponent } from '../create/menu-create.component';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
 
 @Component({
   selector: 'cobbler-menu-overview',
@@ -36,6 +39,9 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
     MatMenuModule,
     MatTooltipModule,
     MatPaginatorModule,
+    MatSort,
+    MatInputModule,
+    MatFormFieldModule,
   ],
   templateUrl: './menu-overview.component.html',
   styleUrl: './menu-overview.component.scss',
@@ -56,6 +62,7 @@ export class MenuOverviewComponent implements OnInit, OnDestroy, AfterViewInit {
 
   @ViewChild(MatTable) table: MatTable<Menu>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
 
   ngOnInit(): void {
     this.retrieveMenus();
@@ -63,11 +70,21 @@ export class MenuOverviewComponent implements OnInit, OnDestroy, AfterViewInit {
 
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
   }
 
   ngOnDestroy(): void {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
   }
 
   private retrieveMenus(): void {

--- a/projects/cobbler-frontend/src/app/items/package/overview/package-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/package/overview/package-overview.component.html
@@ -12,8 +12,16 @@
     >
   </div>
 </div>
-
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<mat-form-field appearance="fill">
+  <mat-label>Filter</mat-label>
+  <input
+    matInput
+    (keyup)="applyFilter($event)"
+    placeholder="Ex. centriq4.arch-test.prg2.suse.org"
+    #input
+  />
+</mat-form-field>
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8" matSort>
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>

--- a/projects/cobbler-frontend/src/app/items/package/overview/package-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/package/overview/package-overview.component.ts
@@ -26,6 +26,9 @@ import { UserService } from '../../../services/user.service';
 import Utils from '../../../utils';
 import { PackageCreateComponent } from '../create/package-create.component';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
 
 @Component({
   selector: 'cobbler-package-overview',
@@ -36,6 +39,9 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
     MatMenuModule,
     MatTooltipModule,
     MatPaginatorModule,
+    MatSort,
+    MatInputModule,
+    MatFormFieldModule,
   ],
   templateUrl: './package-overview.component.html',
   styleUrl: './package-overview.component.scss',
@@ -58,6 +64,7 @@ export class PackageOverviewComponent
 
   @ViewChild(MatTable) table: MatTable<Package>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
 
   ngOnInit(): void {
     this.retrievePackages();
@@ -65,11 +72,21 @@ export class PackageOverviewComponent
 
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
   }
 
   ngOnDestroy(): void {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
   }
 
   private retrievePackages(): void {

--- a/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.html
@@ -12,8 +12,16 @@
     >
   </div>
 </div>
-
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<mat-form-field appearance="fill">
+  <mat-label>Filter</mat-label>
+  <input
+    matInput
+    (keyup)="applyFilter($event)"
+    placeholder="Ex. s390x:SLE-Micro-5.1-GM:install-auto"
+    #input
+  />
+</mat-form-field>
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8" matSort>
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>

--- a/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.ts
@@ -26,6 +26,9 @@ import { UserService } from '../../../services/user.service';
 import Utils from '../../../utils';
 import { ProfileCreateComponent } from '../create/profile-create.component';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSort } from '@angular/material/sort';
 
 @Component({
   selector: 'cobbler-profile-overview',
@@ -36,6 +39,8 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
     MatMenuModule,
     MatTooltipModule,
     MatPaginatorModule,
+    MatFormFieldModule,
+    MatInputModule,
   ],
   templateUrl: './profile-overview.component.html',
   styleUrl: './profile-overview.component.scss',
@@ -58,6 +63,7 @@ export class ProfileOverviewComponent
 
   @ViewChild(MatTable) table: MatTable<Profile>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
 
   ngOnInit(): void {
     this.retrieveProfiles();
@@ -65,11 +71,21 @@ export class ProfileOverviewComponent
 
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
   }
 
   ngOnDestroy(): void {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
   }
 
   private retrieveProfiles(): void {

--- a/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.html
@@ -12,8 +12,16 @@
     >
   </div>
 </div>
-
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<mat-form-field appearance="fill">
+  <mat-label>Filter</mat-label>
+  <input
+    matInput
+    (keyup)="applyFilter($event)"
+    placeholder="Ex. s390x:SLE-Micro-5.1-GM:install-auto"
+    #input
+  />
+</mat-form-field>
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8" matSort>
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>

--- a/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.ts
@@ -26,6 +26,9 @@ import { UserService } from '../../../services/user.service';
 import Utils from '../../../utils';
 import { RepositoryCreateComponent } from '../create/repository-create.component';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSort } from '@angular/material/sort';
 
 @Component({
   selector: 'cobbler-repository-overview',
@@ -36,6 +39,8 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
     MatMenuModule,
     MatTooltipModule,
     MatPaginatorModule,
+    MatInputModule,
+    MatFormFieldModule,
   ],
   templateUrl: './repository-overview.component.html',
   styleUrl: './repository-overview.component.scss',
@@ -58,6 +63,7 @@ export class RepositoryOverviewComponent
 
   @ViewChild(MatTable) table: MatTable<Repo>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
 
   ngOnInit(): void {
     this.retrieveRepositories();
@@ -65,11 +71,21 @@ export class RepositoryOverviewComponent
 
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
   }
 
   ngOnDestroy(): void {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
   }
 
   private retrieveRepositories(): void {

--- a/projects/cobbler-frontend/src/app/items/snippet/overview/snippet-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/snippet/overview/snippet-overview.component.html
@@ -12,8 +12,16 @@
     >
   </div>
 </div>
-
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<mat-form-field appearance="fill">
+  <mat-label>Filter</mat-label>
+  <input
+    matInput
+    (keyup)="applyFilter($event)"
+    placeholder="Ex. keep_files"
+    #input
+  />
+</mat-form-field>
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8" matSort>
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>

--- a/projects/cobbler-frontend/src/app/items/snippet/overview/snippet-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/snippet/overview/snippet-overview.component.ts
@@ -26,6 +26,9 @@ import { UserService } from '../../../services/user.service';
 import Utils from '../../../utils';
 import { SnippetCreateComponent } from '../create/snippet-create.component';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSort } from '@angular/material/sort';
 
 @Component({
   selector: 'cobbler-snippet-overview',
@@ -36,6 +39,8 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
     MatMenuModule,
     MatTooltip,
     MatPaginatorModule,
+    MatFormFieldModule,
+    MatInputModule,
   ],
   templateUrl: './snippet-overview.component.html',
   styleUrl: './snippet-overview.component.scss',
@@ -58,6 +63,7 @@ export class SnippetOverviewComponent
 
   @ViewChild(MatTable) table: MatTable<string>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
 
   ngOnInit(): void {
     this.retrieveSnippets();
@@ -65,11 +71,21 @@ export class SnippetOverviewComponent
 
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
   }
 
   ngOnDestroy(): void {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
   }
 
   private retrieveSnippets(): void {

--- a/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.html
@@ -12,8 +12,16 @@
     >
   </div>
 </div>
-
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<mat-form-field appearance="fill">
+  <mat-label>Filter</mat-label>
+  <input
+    matInput
+    (keyup)="applyFilter($event)"
+    placeholder="Ex. sconsole1.arch-test.prg2.suse.org"
+    #input
+  />
+</mat-form-field>
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8" matSort>
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>

--- a/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.ts
@@ -26,6 +26,9 @@ import { UserService } from '../../../services/user.service';
 import Utils from '../../../utils';
 import { SystemCreateComponent } from '../create/system-create.component';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSort } from '@angular/material/sort';
 
 @Component({
   selector: 'cobbler-system-overview',
@@ -36,6 +39,9 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
     MatTableModule,
     MatTooltip,
     MatPaginatorModule,
+    MatInputModule,
+    MatFormFieldModule,
+    MatSort,
   ],
   templateUrl: './system-overview.component.html',
   styleUrl: './system-overview.component.scss',
@@ -58,6 +64,7 @@ export class SystemOverviewComponent
 
   @ViewChild(MatTable) table: MatTable<System>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
 
   // Show disable netboot
   showDisableNetboot: boolean = true;
@@ -69,11 +76,21 @@ export class SystemOverviewComponent
 
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
   }
 
   ngOnDestroy(): void {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
   }
 
   private retrieveSystems(): void {

--- a/projects/cobbler-frontend/src/app/items/template/overview/template-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/template/overview/template-overview.component.html
@@ -12,8 +12,16 @@
     >
   </div>
 </div>
-
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<mat-form-field appearance="fill">
+  <mat-label>Filter</mat-label>
+  <input
+    matInput
+    (keyup)="applyFilter($event)"
+    placeholder="Ex. legacy.ks"
+    #input
+  />
+</mat-form-field>
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8" matSort>
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>

--- a/projects/cobbler-frontend/src/app/items/template/overview/template-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/template/overview/template-overview.component.ts
@@ -26,6 +26,9 @@ import { UserService } from '../../../services/user.service';
 import Utils from '../../../utils';
 import { TemplateCreateComponent } from '../create/template-create.component';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 
 @Component({
   selector: 'cobbler-template-overview',
@@ -36,6 +39,9 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
     MatMenuModule,
     MatTooltip,
     MatPaginatorModule,
+    MatSort,
+    MatFormFieldModule,
+    MatInputModule,
   ],
   templateUrl: './template-overview.component.html',
   styleUrl: './template-overview.component.scss',
@@ -58,6 +64,7 @@ export class TemplateOverviewComponent
 
   @ViewChild(MatTable) table: MatTable<string>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
 
   ngOnInit(): void {
     this.retrieveTemplates();
@@ -65,11 +72,21 @@ export class TemplateOverviewComponent
 
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
   }
 
   ngOnDestroy(): void {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
   }
 
   private retrieveTemplates(): void {


### PR DESCRIPTION
With this PR, users can now filter data tables by the preferred parameter. 
It also allows to filter the data table on events page by name of the log, state and date which improves user experience. 

Closes #379 and #388 
<img width="1420" height="383" alt="image" src="https://github.com/user-attachments/assets/60277651-b4c3-4139-93d9-46333edcbb47" />
