### PR TITLE
Items: Clickable names & navigation

### DIFF
--- a/projects/cobbler-frontend/src/app/app-events/app-events.component.css
+++ b/projects/cobbler-frontend/src/app/app-events/app-events.component.css
@@ -6,3 +6,9 @@ table {
   display: flex;
   gap: 10px;
 }
+
+a {
+  cursor: pointer;
+  text-decoration: none;
+  color: black;
+}

--- a/projects/cobbler-frontend/src/app/app-events/app-events.component.html
+++ b/projects/cobbler-frontend/src/app/app-events/app-events.component.html
@@ -43,7 +43,9 @@
     <table mat-table [dataSource]="cobblerEvents">
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef>Name</th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element">
+          <a (click)="showLogs(element.id, element.name)">{{ element.name }}</a>
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="state">

--- a/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.html
@@ -38,7 +38,14 @@
   <!-- Breed Column -->
   <ng-container matColumnDef="breed">
     <th mat-header-cell *matHeaderCellDef>Breed</th>
-    <td mat-cell *matCellDef="let element">{{ element.breed }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a [routerLink]="['/signatures']" [queryParams]="{ breed: element.breed }"
+        >{{ element.breed }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
+    </td>
   </ng-container>
 
   <!-- OsVersion Column -->
@@ -49,7 +56,10 @@
         <a
           class="os_version_link"
           [routerLink]="['/signatures']"
-          [queryParams]="{ osVersion: element.os_version }"
+          [queryParams]="{
+            breed: element.breed,
+            osVersion: element.os_version,
+          }"
           >{{ element.os_version }}
           <mat-icon class="link-icon" aria-hidden="true"
             >arrow_outward</mat-icon

--- a/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.html
@@ -25,7 +25,14 @@
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a [routerLink]="['/items', 'distro', element.name]"
+        >{{ element.name }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
+    </td>
   </ng-container>
 
   <!-- Breed Column -->
@@ -37,7 +44,19 @@
   <!-- OsVersion Column -->
   <ng-container matColumnDef="os_version">
     <th mat-header-cell *matHeaderCellDef>Operating System Version</th>
-    <td mat-cell *matCellDef="let element">{{ element.os_version }}</td>
+    <td mat-cell *matCellDef="let element">
+      @if (element.os_version) {
+        <a
+          class="os_version_link"
+          [routerLink]="['/signatures']"
+          [queryParams]="{ osVersion: element.os_version }"
+          >{{ element.os_version }}
+          <mat-icon class="link-icon" aria-hidden="true"
+            >arrow_outward</mat-icon
+          ></a
+        >
+      }
+    </td>
   </ng-container>
 
   <ng-container matColumnDef="actions">

--- a/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.html
@@ -26,7 +26,7 @@
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
     <td mat-cell *matCellDef="let element">
-      <a [routerLink]="['/items', 'distro', element.name]"
+      <a (click)="showDistro(element.uid, element.name)"
         >{{ element.name }}
         <mat-icon class="link-icon" aria-hidden="true"
           >arrow_outward</mat-icon

--- a/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.scss
@@ -33,6 +33,8 @@ a {
   align-items: center;
   text-decoration: none;
   color: black;
+  cursor: pointer;
+  width: fit-content;
 }
 
 .link-icon {

--- a/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.scss
@@ -27,3 +27,18 @@
 .form-field-full-width {
   width: 100%;
 }
+
+a {
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  color: black;
+}
+
+.link-icon {
+  margin-left: 5px;
+  font-size: 16px;
+  width: 20px;
+  height: 20px;
+  color: #0000004b;
+}

--- a/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.ts
@@ -18,7 +18,7 @@ import {
   MatTableModule,
 } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { CobblerApiService, Distro } from 'cobbler-api';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -45,6 +45,7 @@ import { MatInputModule } from '@angular/material/input';
     MatFormFieldModule,
     MatInputModule,
     MatSort,
+    RouterLink,
   ],
 })
 export class DistrosOverviewComponent

--- a/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/distro/overview/distros-overview.component.ts
@@ -1,11 +1,11 @@
 import {
   AfterViewInit,
   Component,
+  ElementRef,
   OnDestroy,
   OnInit,
   ViewChild,
   inject,
-  viewChild,
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
@@ -18,7 +18,7 @@ import {
   MatTableModule,
 } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { CobblerApiService, Distro } from 'cobbler-api';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -56,6 +56,8 @@ export class DistrosOverviewComponent
   private _snackBar = inject(MatSnackBar);
   private router = inject(Router);
   readonly dialog = inject<MatDialog>(MatDialog);
+  private route = inject(ActivatedRoute);
+  private targetDistro: string | null = null;
 
   // Unsubscribe
   private ngUnsubscribe = new Subject<void>();
@@ -64,17 +66,26 @@ export class DistrosOverviewComponent
   displayedColumns: string[] = ['name', 'breed', 'os_version', 'actions'];
   dataSource = new MatTableDataSource<Distro>([]);
 
-  @ViewChild(MatTable) table: MatTable<Distro>;
+  @ViewChild(MatTable) table!: MatTable<Distro>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;
+  @ViewChild('input') filterField!: ElementRef<HTMLInputElement>;
 
   ngOnInit(): void {
     this.retrieveDistros();
+    this.targetDistro = this.route.snapshot.queryParamMap.get('distro');
   }
 
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
+
+    if (this.targetDistro) {
+      this.filterField.nativeElement.value = this.targetDistro;
+      this.dataSource.filter = this.targetDistro;
+    } else {
+      this.filterField.nativeElement.value = '';
+    }
   }
 
   ngOnDestroy(): void {
@@ -89,6 +100,13 @@ export class DistrosOverviewComponent
     if (this.dataSource.paginator) {
       this.dataSource.paginator.firstPage();
     }
+
+    // Remove query param on URL when filtering
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { distro: null },
+      queryParamsHandling: 'merge',
+    });
   }
 
   private retrieveDistros(): void {

--- a/projects/cobbler-frontend/src/app/items/file/overview/file-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/file/overview/file-overview.component.html
@@ -22,7 +22,12 @@
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
     <td mat-cell *matCellDef="let element">
-      <a [routerLink]="['/items', 'file', element.name]">{{ element.name }}</a>
+      <a (click)="showDistro(element.uid, element.name)"
+        >{{ element.name }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
     </td>
   </ng-container>
 

--- a/projects/cobbler-frontend/src/app/items/file/overview/file-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/file/overview/file-overview.component.html
@@ -21,7 +21,9 @@
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a [routerLink]="['/items', 'file', element.name]">{{ element.name }}</a>
+    </td>
   </ng-container>
 
   <!-- Action Column -->

--- a/projects/cobbler-frontend/src/app/items/file/overview/file-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/file/overview/file-overview.component.scss
@@ -27,3 +27,8 @@
 .form-field-full-width {
   width: 100%;
 }
+
+a {
+  text-decoration: none;
+  color: black;
+}

--- a/projects/cobbler-frontend/src/app/items/file/overview/file-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/file/overview/file-overview.component.scss
@@ -29,6 +29,18 @@
 }
 
 a {
+  display: flex;
+  align-items: center;
   text-decoration: none;
   color: black;
+  cursor: pointer;
+  width: fit-content;
+}
+
+.link-icon {
+  margin-left: 5px;
+  font-size: 16px;
+  width: 20px;
+  height: 20px;
+  color: #0000004b;
 }

--- a/projects/cobbler-frontend/src/app/items/file/overview/file-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/file/overview/file-overview.component.ts
@@ -25,7 +25,7 @@ import {
   MatTableDataSource,
 } from '@angular/material/table';
 import { MatTooltip } from '@angular/material/tooltip';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { CobblerApiService, File } from 'cobbler-api';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -61,6 +61,7 @@ import { MatSort } from '@angular/material/sort';
     MatInputModule,
     MatFormFieldModule,
     MatSort,
+    RouterLink,
   ],
   templateUrl: './file-overview.component.html',
   styleUrl: './file-overview.component.scss',

--- a/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.html
@@ -22,7 +22,12 @@
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
     <td mat-cell *matCellDef="let element">
-      <a [routerLink]="['/items', 'image', element.name]">{{ element.name }}</a>
+      <a (click)="showImage(element.uid, element.name)"
+        >{{ element.name }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
     </td>
   </ng-container>
 
@@ -41,7 +46,16 @@
   <!-- OsVersion Column -->
   <ng-container matColumnDef="os_version">
     <th mat-header-cell *matHeaderCellDef>Operating System Version</th>
-    <td mat-cell *matCellDef="let element">{{ element.os_version }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a
+        [routerLink]="['signatures']"
+        [queryParams]="{ osVersion: element.os_version }"
+        >{{ element.os_version }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
+    </td>
   </ng-container>
 
   <ng-container matColumnDef="actions">

--- a/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.html
@@ -21,7 +21,9 @@
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a [routerLink]="['/items', 'image', element.name]">{{ element.name }}</a>
+    </td>
   </ng-container>
 
   <!-- Arch Column -->

--- a/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.html
@@ -40,7 +40,14 @@
   <!-- Breed Column -->
   <ng-container matColumnDef="breed">
     <th mat-header-cell *matHeaderCellDef>Breed</th>
-    <td mat-cell *matCellDef="let element">{{ element.breed }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a [routerLink]="['/signatures']" [queryParams]="{ breed: element.breed }"
+        >{{ element.breed }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
+    </td>
   </ng-container>
 
   <!-- OsVersion Column -->
@@ -49,7 +56,7 @@
     <td mat-cell *matCellDef="let element">
       <a
         [routerLink]="['signatures']"
-        [queryParams]="{ osVersion: element.os_version }"
+        [queryParams]="{ breed: element.breed, osVersion: element.os_version }"
         >{{ element.os_version }}
         <mat-icon class="link-icon" aria-hidden="true"
           >arrow_outward</mat-icon

--- a/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.scss
@@ -27,3 +27,8 @@
 .form-field-full-width {
   width: 100%;
 }
+
+a {
+  text-decoration: none;
+  color: black;
+}

--- a/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.scss
@@ -29,6 +29,18 @@
 }
 
 a {
+  display: flex;
+  align-items: center;
   text-decoration: none;
   color: black;
+  cursor: pointer;
+  width: fit-content;
+}
+
+.link-icon {
+  margin-left: 5px;
+  font-size: 16px;
+  width: 20px;
+  height: 20px;
+  color: #0000004b;
 }

--- a/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.spec.ts
+++ b/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { COBBLER_URL } from 'cobbler-api';
 
 import { ImageOverviewComponent } from './image-overview.component';
+import { provideRouter } from '@angular/router';
 
 describe('ImageOverviewComponent', () => {
   let component: ImageOverviewComponent;
@@ -13,6 +14,7 @@ describe('ImageOverviewComponent', () => {
     await TestBed.configureTestingModule({
       imports: [ImageOverviewComponent],
       providers: [
+        provideRouter([]),
         provideHttpClient(),
         provideHttpClientTesting(),
         {

--- a/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.ts
@@ -1,6 +1,7 @@
 import {
   AfterViewInit,
   Component,
+  ElementRef,
   OnDestroy,
   OnInit,
   ViewChild,
@@ -17,7 +18,7 @@ import {
   MatTableModule,
 } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { CobblerApiService, Image } from 'cobbler-api';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -55,6 +56,8 @@ export class ImageOverviewComponent
   private _snackBar = inject(MatSnackBar);
   private router = inject(Router);
   readonly dialog = inject<MatDialog>(MatDialog);
+  private route = inject(ActivatedRoute);
+  private targetImage: string | null = null;
 
   // Unsubscribe
   private ngUnsubscribe = new Subject<void>();
@@ -69,17 +72,26 @@ export class ImageOverviewComponent
   ];
   dataSource = new MatTableDataSource<Image>([]);
 
-  @ViewChild(MatTable) table: MatTable<Image>;
+  @ViewChild(MatTable) table!: MatTable<Image>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;
+  @ViewChild('input') filterField!: ElementRef<HTMLInputElement>;
 
   ngOnInit(): void {
     this.retrieveImages();
+    this.targetImage = this.route.snapshot.queryParamMap.get('image');
   }
 
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
+
+    if (this.targetImage) {
+      this.filterField.nativeElement.value = this.targetImage;
+      this.dataSource.filter = this.targetImage;
+    } else {
+      this.filterField.nativeElement.value = '';
+    }
   }
 
   ngOnDestroy(): void {
@@ -94,6 +106,13 @@ export class ImageOverviewComponent
     if (this.dataSource.paginator) {
       this.dataSource.paginator.firstPage();
     }
+
+    // Remove query param on URL when filtering
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { image: null },
+      queryParamsHandling: 'merge',
+    });
   }
 
   private retrieveImages(): void {

--- a/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/image/overview/image-overview.component.ts
@@ -17,7 +17,7 @@ import {
   MatTableModule,
 } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { CobblerApiService, Image } from 'cobbler-api';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -42,6 +42,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
     MatSort,
     MatInputModule,
     MatFormFieldModule,
+    RouterLink,
   ],
   templateUrl: './image-overview.component.html',
   styleUrl: './image-overview.component.scss',

--- a/projects/cobbler-frontend/src/app/items/management-class/overview/management-class-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/management-class/overview/management-class-overview.component.html
@@ -25,7 +25,11 @@
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a [routerLink]="['/items', 'management-class', element.name]">{{
+        element.name
+      }}</a>
+    </td>
   </ng-container>
 
   <!-- Class Name Column -->

--- a/projects/cobbler-frontend/src/app/items/management-class/overview/management-class-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/management-class/overview/management-class-overview.component.html
@@ -26,9 +26,12 @@
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
     <td mat-cell *matCellDef="let element">
-      <a [routerLink]="['/items', 'management-class', element.name]">{{
-        element.name
-      }}</a>
+      <a (click)="showManagementClass(element.uid, element.name)"
+        >{{ element.name }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
     </td>
   </ng-container>
 

--- a/projects/cobbler-frontend/src/app/items/management-class/overview/management-class-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/management-class/overview/management-class-overview.component.scss
@@ -27,3 +27,8 @@
 .form-field-full-width {
   width: 100%;
 }
+
+a {
+  text-decoration: none;
+  color: black;
+}

--- a/projects/cobbler-frontend/src/app/items/management-class/overview/management-class-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/management-class/overview/management-class-overview.component.scss
@@ -29,6 +29,18 @@
 }
 
 a {
+  display: flex;
+  align-items: center;
   text-decoration: none;
   color: black;
+  cursor: pointer;
+  width: fit-content;
+}
+
+.link-icon {
+  margin-left: 5px;
+  font-size: 16px;
+  width: 20px;
+  height: 20px;
+  color: #0000004b;
 }

--- a/projects/cobbler-frontend/src/app/items/management-class/overview/management-class-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/management-class/overview/management-class-overview.component.ts
@@ -17,7 +17,7 @@ import {
   MatTableModule,
 } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { CobblerApiService, Mgmgtclass } from 'cobbler-api';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -42,6 +42,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
     MatSort,
     MatInputModule,
     MatFormFieldModule,
+    RouterLink,
   ],
   templateUrl: './management-class-overview.component.html',
   styleUrl: './management-class-overview.component.scss',

--- a/projects/cobbler-frontend/src/app/items/menu/overview/menu-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/menu/overview/menu-overview.component.html
@@ -22,7 +22,12 @@
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
     <td mat-cell *matCellDef="let element">
-      <a [routerLink]="['/items', 'menu', element.name]">{{ element.name }}</a>
+      <a (click)="showMenu(element.uid, element.name)"
+        >{{ element.name }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
     </td>
   </ng-container>
 

--- a/projects/cobbler-frontend/src/app/items/menu/overview/menu-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/menu/overview/menu-overview.component.html
@@ -21,7 +21,9 @@
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a [routerLink]="['/items', 'menu', element.name]">{{ element.name }}</a>
+    </td>
   </ng-container>
 
   <!-- Display Name Column -->

--- a/projects/cobbler-frontend/src/app/items/menu/overview/menu-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/menu/overview/menu-overview.component.scss
@@ -27,3 +27,8 @@
 .form-field-full-width {
   width: 100%;
 }
+
+a {
+  text-decoration: none;
+  color: black;
+}

--- a/projects/cobbler-frontend/src/app/items/menu/overview/menu-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/menu/overview/menu-overview.component.scss
@@ -29,6 +29,18 @@
 }
 
 a {
+  display: flex;
+  align-items: center;
   text-decoration: none;
   color: black;
+  cursor: pointer;
+  width: fit-content;
+}
+
+.link-icon {
+  margin-left: 5px;
+  font-size: 16px;
+  width: 20px;
+  height: 20px;
+  color: #0000004b;
 }

--- a/projects/cobbler-frontend/src/app/items/menu/overview/menu-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/menu/overview/menu-overview.component.ts
@@ -17,7 +17,7 @@ import {
   MatTableModule,
 } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { CobblerApiService, Menu } from 'cobbler-api';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -42,6 +42,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
     MatSort,
     MatInputModule,
     MatFormFieldModule,
+    RouterLink,
   ],
   templateUrl: './menu-overview.component.html',
   styleUrl: './menu-overview.component.scss',

--- a/projects/cobbler-frontend/src/app/items/package/overview/package-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/package/overview/package-overview.component.html
@@ -25,7 +25,11 @@
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a [routerLink]="['/items', 'package', element.name]">{{
+        element.name
+      }}</a>
+    </td>
   </ng-container>
 
   <!-- Installer Column -->

--- a/projects/cobbler-frontend/src/app/items/package/overview/package-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/package/overview/package-overview.component.html
@@ -26,9 +26,12 @@
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
     <td mat-cell *matCellDef="let element">
-      <a [routerLink]="['/items', 'package', element.name]">{{
-        element.name
-      }}</a>
+      <a (click)="showPackage(element.uid, element.name)"
+        >{{ element.name }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
     </td>
   </ng-container>
 

--- a/projects/cobbler-frontend/src/app/items/package/overview/package-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/package/overview/package-overview.component.scss
@@ -27,3 +27,8 @@
 .form-field-full-width {
   width: 100%;
 }
+
+a {
+  text-decoration: none;
+  color: black;
+}

--- a/projects/cobbler-frontend/src/app/items/package/overview/package-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/package/overview/package-overview.component.scss
@@ -29,6 +29,18 @@
 }
 
 a {
+  display: flex;
+  align-items: center;
   text-decoration: none;
   color: black;
+  cursor: pointer;
+  width: fit-content;
+}
+
+.link-icon {
+  margin-left: 5px;
+  font-size: 16px;
+  width: 20px;
+  height: 20px;
+  color: #0000004b;
 }

--- a/projects/cobbler-frontend/src/app/items/package/overview/package-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/package/overview/package-overview.component.ts
@@ -17,7 +17,7 @@ import {
   MatTableModule,
 } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { CobblerApiService, Package } from 'cobbler-api';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -42,6 +42,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
     MatSort,
     MatInputModule,
     MatFormFieldModule,
+    RouterLink,
   ],
   templateUrl: './package-overview.component.html',
   styleUrl: './package-overview.component.scss',

--- a/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.html
@@ -25,7 +25,14 @@
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a [routerLink]="['/items', 'profile', element.name]"
+        >{{ element.name }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
+    </td>
   </ng-container>
 
   <!-- Distro Column -->

--- a/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.html
@@ -26,7 +26,7 @@
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
     <td mat-cell *matCellDef="let element">
-      <a [routerLink]="['/items', 'profile', element.name]"
+      <a (click)="showProfile(element.uid, element.name)"
         >{{ element.name }}
         <mat-icon class="link-icon" aria-hidden="true"
           >arrow_outward</mat-icon
@@ -38,7 +38,16 @@
   <!-- Distro Column -->
   <ng-container matColumnDef="distro">
     <th mat-header-cell *matHeaderCellDef>Distro</th>
-    <td mat-cell *matCellDef="let element">{{ element.distro }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a
+        [routerLink]="['/items', 'distro']"
+        [queryParams]="{ distro: element.distro }"
+        >{{ element.distro }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
+    </td>
   </ng-container>
 
   <!-- Server Column -->

--- a/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.scss
@@ -33,6 +33,8 @@ a {
   align-items: center;
   text-decoration: none;
   color: black;
+  cursor: pointer;
+  width: fit-content;
 }
 
 .link-icon {

--- a/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.scss
@@ -27,3 +27,18 @@
 .form-field-full-width {
   width: 100%;
 }
+
+a {
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  color: black;
+}
+
+.link-icon {
+  margin-left: 5px;
+  font-size: 16px;
+  width: 20px;
+  height: 20px;
+  color: #0000004b;
+}

--- a/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.ts
@@ -1,6 +1,7 @@
 import {
   AfterViewInit,
   Component,
+  ElementRef,
   OnDestroy,
   OnInit,
   ViewChild,
@@ -17,7 +18,7 @@ import {
   MatTableModule,
 } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { CobblerApiService, Profile } from 'cobbler-api';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -55,6 +56,8 @@ export class ProfileOverviewComponent
   private _snackBar = inject(MatSnackBar);
   private router = inject(Router);
   readonly dialog = inject<MatDialog>(MatDialog);
+  private route = inject(ActivatedRoute);
+  private targetProfile: string | null = null;
 
   // Unsubscribe
   private ngUnsubscribe = new Subject<void>();
@@ -63,17 +66,26 @@ export class ProfileOverviewComponent
   displayedColumns: string[] = ['name', 'distro', 'server', 'actions'];
   dataSource = new MatTableDataSource<Profile>([]);
 
-  @ViewChild(MatTable) table: MatTable<Profile>;
+  @ViewChild(MatTable) table!: MatTable<Profile>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;
+  @ViewChild('input') filterField!: ElementRef<HTMLInputElement>;
 
   ngOnInit(): void {
     this.retrieveProfiles();
+    this.targetProfile = this.route.snapshot.queryParamMap.get('profile');
   }
 
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
+
+    if (this.targetProfile) {
+      this.filterField.nativeElement.value = this.targetProfile;
+      this.dataSource.filter = this.targetProfile;
+    } else {
+      this.filterField.nativeElement.value = '';
+    }
   }
 
   ngOnDestroy(): void {
@@ -88,6 +100,13 @@ export class ProfileOverviewComponent
     if (this.dataSource.paginator) {
       this.dataSource.paginator.firstPage();
     }
+
+    // Remove query param on URL when filtering
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { profile: null },
+      queryParamsHandling: 'merge',
+    });
   }
 
   private retrieveProfiles(): void {

--- a/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/profile/overview/profile-overview.component.ts
@@ -17,7 +17,7 @@ import {
   MatTableModule,
 } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { CobblerApiService, Profile } from 'cobbler-api';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -41,6 +41,8 @@ import { MatSort } from '@angular/material/sort';
     MatPaginatorModule,
     MatFormFieldModule,
     MatInputModule,
+    MatSort,
+    RouterLink,
   ],
   templateUrl: './profile-overview.component.html',
   styleUrl: './profile-overview.component.scss',

--- a/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.html
@@ -25,7 +25,11 @@
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a [routerLink]="['/items', 'repository', element.name]">{{
+        element.name
+      }}</a>
+    </td>
   </ng-container>
 
   <!-- Breed Column -->

--- a/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.html
@@ -26,9 +26,12 @@
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
     <td mat-cell *matCellDef="let element">
-      <a [routerLink]="['/items', 'repository', element.name]">{{
-        element.name
-      }}</a>
+      <a (click)="showRepository(element.uid, element.name)"
+        >{{ element.name }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
     </td>
   </ng-container>
 

--- a/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.html
@@ -38,7 +38,14 @@
   <!-- Breed Column -->
   <ng-container matColumnDef="breed">
     <th mat-header-cell *matHeaderCellDef>Breed</th>
-    <td mat-cell *matCellDef="let element">{{ element.breed }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a [routerLink]="['/signatures']" [queryParams]="{ breed: element.breed }"
+        >{{ element.breed }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
+    </td>
   </ng-container>
 
   <!-- mirror_type Column -->

--- a/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.scss
@@ -27,3 +27,8 @@
 .form-field-full-width {
   width: 100%;
 }
+
+a {
+  text-decoration: none;
+  color: black;
+}

--- a/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.scss
@@ -29,6 +29,18 @@
 }
 
 a {
+  display: flex;
+  align-items: center;
   text-decoration: none;
   color: black;
+  cursor: pointer;
+  width: fit-content;
+}
+
+.link-icon {
+  margin-left: 5px;
+  font-size: 16px;
+  width: 20px;
+  height: 20px;
+  color: #0000004b;
 }

--- a/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.ts
@@ -17,7 +17,7 @@ import {
   MatTableModule,
 } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { CobblerApiService, Repo } from 'cobbler-api';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -41,6 +41,8 @@ import { MatSort } from '@angular/material/sort';
     MatPaginatorModule,
     MatInputModule,
     MatFormFieldModule,
+    MatSort,
+    RouterLink,
   ],
   templateUrl: './repository-overview.component.html',
   styleUrl: './repository-overview.component.scss',

--- a/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/repository/overview/repository-overview.component.ts
@@ -42,7 +42,6 @@ import { MatSort } from '@angular/material/sort';
     MatInputModule,
     MatFormFieldModule,
     MatSort,
-    RouterLink,
   ],
   templateUrl: './repository-overview.component.html',
   styleUrl: './repository-overview.component.scss',
@@ -63,7 +62,7 @@ export class RepositoryOverviewComponent
   displayedColumns: string[] = ['name', 'breed', 'mirror_type', 'actions'];
   dataSource = new MatTableDataSource<Repo>([]);
 
-  @ViewChild(MatTable) table: MatTable<Repo>;
+  @ViewChild(MatTable) table!: MatTable<Repo>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;
 

--- a/projects/cobbler-frontend/src/app/items/snippet/overview/snippet-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/snippet/overview/snippet-overview.component.html
@@ -25,7 +25,9 @@
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let element">{{ element }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a [routerLink]="['/items', 'snippet', element]">{{ element }}</a>
+    </td>
   </ng-container>
 
   <ng-container matColumnDef="actions">

--- a/projects/cobbler-frontend/src/app/items/snippet/overview/snippet-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/snippet/overview/snippet-overview.component.html
@@ -26,7 +26,12 @@
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
     <td mat-cell *matCellDef="let element">
-      <a [routerLink]="['/items', 'snippet', element]">{{ element }}</a>
+      <a (click)="showSnippet(element)"
+        >{{ element }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
     </td>
   </ng-container>
 

--- a/projects/cobbler-frontend/src/app/items/snippet/overview/snippet-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/snippet/overview/snippet-overview.component.scss
@@ -27,3 +27,8 @@
 .form-field-full-width {
   width: 100%;
 }
+
+a {
+  text-decoration: none;
+  color: black;
+}

--- a/projects/cobbler-frontend/src/app/items/snippet/overview/snippet-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/snippet/overview/snippet-overview.component.scss
@@ -29,6 +29,18 @@
 }
 
 a {
+  display: flex;
+  align-items: center;
   text-decoration: none;
   color: black;
+  cursor: pointer;
+  width: fit-content;
+}
+
+.link-icon {
+  margin-left: 5px;
+  font-size: 16px;
+  width: 20px;
+  height: 20px;
+  color: #0000004b;
 }

--- a/projects/cobbler-frontend/src/app/items/snippet/overview/snippet-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/snippet/overview/snippet-overview.component.ts
@@ -17,7 +17,7 @@ import {
   MatTableModule,
 } from '@angular/material/table';
 import { MatTooltip } from '@angular/material/tooltip';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { CobblerApiService } from 'cobbler-api';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -41,6 +41,7 @@ import { MatSort } from '@angular/material/sort';
     MatPaginatorModule,
     MatFormFieldModule,
     MatInputModule,
+    RouterLink,
   ],
   templateUrl: './snippet-overview.component.html',
   styleUrl: './snippet-overview.component.scss',

--- a/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.html
@@ -25,7 +25,11 @@
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a [routerLink]="['/items', 'system', element.name]">{{
+        element.name
+      }}</a>
+    </td>
   </ng-container>
 
   <!-- Profile Column -->

--- a/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.html
@@ -26,22 +26,46 @@
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
     <td mat-cell *matCellDef="let element">
-      <a [routerLink]="['/items', 'system', element.name]">{{
-        element.name
-      }}</a>
+      <a (click)="showSystem(element.uid, element.name)"
+        >{{ element.name }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
     </td>
   </ng-container>
 
   <!-- Profile Column -->
   <ng-container matColumnDef="profile">
     <th mat-header-cell *matHeaderCellDef>Profile</th>
-    <td mat-cell *matCellDef="let element">{{ element.profile }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a
+        [routerLink]="['/items', 'profile']"
+        [queryParams]="{ profile: element.name }"
+      >
+        {{ element.name }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
+    </td>
   </ng-container>
 
   <!-- Image Column -->
   <ng-container matColumnDef="image">
     <th mat-header-cell *matHeaderCellDef>Image</th>
-    <td mat-cell *matCellDef="let element">{{ element.image }}</td>
+    <td mat-cell *matCellDef="let element">
+      @if (element.image) {
+        <a
+          [routerLink]="['/items', 'image']"
+          [queryParams]="{ image: element.image }"
+          >{{ element.image }}
+          <mat-icon class="link-icon" aria-hidden="true"
+            >arrow_outward</mat-icon
+          ></a
+        >
+      }
+    </td>
   </ng-container>
 
   <ng-container matColumnDef="actions">

--- a/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.scss
@@ -27,3 +27,8 @@
 .form-field-full-width {
   width: 100%;
 }
+
+a {
+  text-decoration: none;
+  color: black;
+}

--- a/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.scss
@@ -29,6 +29,18 @@
 }
 
 a {
+  display: flex;
+  align-items: center;
   text-decoration: none;
   color: black;
+  cursor: pointer;
+  width: fit-content;
+}
+
+.link-icon {
+  margin-left: 5px;
+  font-size: 16px;
+  width: 20px;
+  height: 20px;
+  color: #0000004b;
 }

--- a/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.ts
@@ -17,7 +17,7 @@ import {
   MatTableModule,
 } from '@angular/material/table';
 import { MatTooltip } from '@angular/material/tooltip';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { CobblerApiService, System } from 'cobbler-api';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -42,6 +42,7 @@ import { MatSort } from '@angular/material/sort';
     MatInputModule,
     MatFormFieldModule,
     MatSort,
+    RouterLink,
   ],
   templateUrl: './system-overview.component.html',
   styleUrl: './system-overview.component.scss',

--- a/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/system/overview/system-overview.component.ts
@@ -1,6 +1,7 @@
 import {
   AfterViewInit,
   Component,
+  ElementRef,
   OnDestroy,
   OnInit,
   ViewChild,
@@ -63,7 +64,7 @@ export class SystemOverviewComponent
   displayedColumns: string[] = ['name', 'profile', 'image', 'actions'];
   dataSource = new MatTableDataSource<System>([]);
 
-  @ViewChild(MatTable) table: MatTable<System>;
+  @ViewChild(MatTable) table!: MatTable<System>;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;
 

--- a/projects/cobbler-frontend/src/app/items/template/overview/template-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/template/overview/template-overview.component.html
@@ -26,7 +26,12 @@
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
     <td mat-cell *matCellDef="let element">
-      <a [routerLink]="['/items', 'template', element]">{{ element }}</a>
+      <a (click)="showTemplate(element)"
+        >{{ element }}
+        <mat-icon class="link-icon" aria-hidden="true"
+          >arrow_outward</mat-icon
+        ></a
+      >
     </td>
   </ng-container>
 

--- a/projects/cobbler-frontend/src/app/items/template/overview/template-overview.component.html
+++ b/projects/cobbler-frontend/src/app/items/template/overview/template-overview.component.html
@@ -25,7 +25,9 @@
   <!-- Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let element">{{ element }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a [routerLink]="['/items', 'template', element]">{{ element }}</a>
+    </td>
   </ng-container>
 
   <ng-container matColumnDef="actions">

--- a/projects/cobbler-frontend/src/app/items/template/overview/template-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/template/overview/template-overview.component.scss
@@ -27,3 +27,8 @@
 .form-field-full-width {
   width: 100%;
 }
+
+a {
+  text-decoration: none;
+  color: black;
+}

--- a/projects/cobbler-frontend/src/app/items/template/overview/template-overview.component.scss
+++ b/projects/cobbler-frontend/src/app/items/template/overview/template-overview.component.scss
@@ -29,6 +29,18 @@
 }
 
 a {
+  display: flex;
+  align-items: center;
   text-decoration: none;
   color: black;
+  cursor: pointer;
+  width: fit-content;
+}
+
+.link-icon {
+  margin-left: 5px;
+  font-size: 16px;
+  width: 20px;
+  height: 20px;
+  color: #0000004b;
 }

--- a/projects/cobbler-frontend/src/app/items/template/overview/template-overview.component.ts
+++ b/projects/cobbler-frontend/src/app/items/template/overview/template-overview.component.ts
@@ -17,7 +17,7 @@ import {
   MatTableModule,
 } from '@angular/material/table';
 import { MatTooltip } from '@angular/material/tooltip';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { CobblerApiService } from 'cobbler-api';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -42,6 +42,7 @@ import { MatInputModule } from '@angular/material/input';
     MatSort,
     MatFormFieldModule,
     MatInputModule,
+    RouterLink,
   ],
   templateUrl: './template-overview.component.html',
   styleUrl: './template-overview.component.scss',

--- a/projects/cobbler-frontend/src/app/signatures/signatures.component.html
+++ b/projects/cobbler-frontend/src/app/signatures/signatures.component.html
@@ -24,6 +24,7 @@
     <mat-tree-node
       *matTreeNodeDef="let node; when: hasChild"
       matTreeNodePadding
+      [id]="'node-' + node.data"
     >
       <button
         mat-icon-button

--- a/projects/cobbler-frontend/src/app/signatures/signatures.component.spec.ts
+++ b/projects/cobbler-frontend/src/app/signatures/signatures.component.spec.ts
@@ -6,6 +6,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { MatTreeModule } from '@angular/material/tree';
 import { COBBLER_URL } from 'cobbler-api';
+import { provideRouter } from '@angular/router';
 
 import { SignaturesComponent } from './signatures.component';
 
@@ -25,6 +26,7 @@ describe('SignaturesComponent', () => {
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),
+        provideRouter([]),
         {
           provide: COBBLER_URL,
           useValue: new URL('http://localhost/cobbler_api'),

--- a/projects/cobbler-frontend/src/app/signatures/signatures.component.ts
+++ b/projects/cobbler-frontend/src/app/signatures/signatures.component.ts
@@ -218,14 +218,14 @@ export class SignaturesComponent implements OnInit, OnDestroy {
   }
 
   expandToOsVersion(osVersion: string): void {
-    const targetBreed = this.dataSource.data.find((breedNode) =>
+    const targetAttribute = this.dataSource.data.find((breedNode) =>
       breedNode.children?.some((child) => child.data === osVersion),
     );
 
-    if (!targetBreed) return;
+    if (!targetAttribute) return;
 
     const breedFlatNode = this.treeControl.dataNodes.find(
-      (node) => node.data === targetBreed.data,
+      (node) => node.data === targetAttribute.data,
     );
     if (breedFlatNode) {
       this.treeControl.expand(breedFlatNode);
@@ -238,7 +238,7 @@ export class SignaturesComponent implements OnInit, OnDestroy {
       this.treeControl.expand(osVersionFlatNode);
     }
 
-    // Scrolls to the target table after it's rendered in 150ms.
+    // Scroll to the target table after it's rendered in 150ms.
     setTimeout(() => {
       const element = document.getElementById('node-' + osVersion);
       if (element) {

--- a/projects/cobbler-frontend/src/app/signatures/signatures.component.ts
+++ b/projects/cobbler-frontend/src/app/signatures/signatures.component.ts
@@ -92,6 +92,7 @@ export class SignaturesComponent implements OnInit, OnDestroy {
   private _snackBar = inject(MatSnackBar);
   private route = inject(ActivatedRoute);
   private targetOsVersion: string | null = null;
+  private targetBreed: string | null = null;
 
   @ViewChild('targetElement') targetTable!: ElementRef<HTMLDivElement>;
 
@@ -141,6 +142,7 @@ export class SignaturesComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.targetOsVersion = this.route.snapshot.queryParamMap.get('osVersion');
+    this.targetBreed = this.route.snapshot.queryParamMap.get('breed');
     this.generateSignatureUiData();
   }
 
@@ -179,7 +181,11 @@ export class SignaturesComponent implements OnInit, OnDestroy {
           this.isLoading = false;
 
           if (this.targetOsVersion) {
-            this.expandToOsVersion(this.targetOsVersion);
+            this.expandToTarget(this.targetBreed!, this.targetOsVersion);
+          } else {
+            if (this.targetBreed) {
+              this.expandToTarget(this.targetBreed, null);
+            }
           }
         },
         (error) => {
@@ -217,30 +223,35 @@ export class SignaturesComponent implements OnInit, OnDestroy {
       );
   }
 
-  expandToOsVersion(osVersion: string): void {
-    const targetAttribute = this.dataSource.data.find((breedNode) =>
-      breedNode.children?.some((child) => child.data === osVersion),
+  expandToTarget(breed: string, osVersion: string | null) {
+    let item = breed;
+
+    const targetBreed = this.dataSource.data.find(
+      (breedNode) => breedNode.data === breed,
     );
 
-    if (!targetAttribute) return;
+    if (!targetBreed) return;
 
     const breedFlatNode = this.treeControl.dataNodes.find(
-      (node) => node.data === targetAttribute.data,
+      (node) => node.data === targetBreed.data,
     );
     if (breedFlatNode) {
       this.treeControl.expand(breedFlatNode);
     }
 
-    const osVersionFlatNode = this.treeControl.dataNodes.find(
-      (node) => node.data === osVersion,
-    );
-    if (osVersionFlatNode) {
-      this.treeControl.expand(osVersionFlatNode);
+    if (osVersion) {
+      item = osVersion;
+      const osVersionFlatNode = this.treeControl.dataNodes.find(
+        (node) => node.data === osVersion,
+      );
+      if (osVersionFlatNode) {
+        this.treeControl.expand(osVersionFlatNode);
+      }
     }
 
     // Scroll to the target table after it's rendered in 150ms.
     setTimeout(() => {
-      const element = document.getElementById('node-' + osVersion);
+      const element = document.getElementById('node-' + item);
       if (element) {
         element.scrollIntoView({
           behavior: 'smooth',

--- a/projects/cobbler-frontend/src/app/signatures/signatures.component.ts
+++ b/projects/cobbler-frontend/src/app/signatures/signatures.component.ts
@@ -1,4 +1,12 @@
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  QueryList,
+  ViewChild,
+  inject,
+} from '@angular/core';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import {
@@ -30,6 +38,7 @@ import { MatIcon } from '@angular/material/icon';
 import { MatIconButton } from '@angular/material/button';
 import { Subject } from 'rxjs';
 import Utils from '../utils';
+import { ActivatedRoute } from '@angular/router';
 
 interface TableRow {
   key: string;
@@ -81,6 +90,10 @@ export class SignaturesComponent implements OnInit, OnDestroy {
   userService = inject(UserService);
   private cobblerApiService = inject(CobblerApiService);
   private _snackBar = inject(MatSnackBar);
+  private route = inject(ActivatedRoute);
+  private targetOsVersion: string | null = null;
+
+  @ViewChild('targetElement') targetTable!: ElementRef<HTMLDivElement>;
 
   // Unsubscribe
   private ngUnsubscribe = new Subject<void>();
@@ -127,6 +140,7 @@ export class SignaturesComponent implements OnInit, OnDestroy {
   public isLoading = true;
 
   ngOnInit(): void {
+    this.targetOsVersion = this.route.snapshot.queryParamMap.get('osVersion');
     this.generateSignatureUiData();
   }
 
@@ -163,6 +177,10 @@ export class SignaturesComponent implements OnInit, OnDestroy {
           }
           this.dataSource.data = newData;
           this.isLoading = false;
+
+          if (this.targetOsVersion) {
+            this.expandToOsVersion(this.targetOsVersion);
+          }
         },
         (error) => {
           // HTML encode the error message since it originates from XML
@@ -197,5 +215,38 @@ export class SignaturesComponent implements OnInit, OnDestroy {
           this._snackBar.open(Utils.toHTML(error.message), 'Close');
         },
       );
+  }
+
+  expandToOsVersion(osVersion: string): void {
+    const targetBreed = this.dataSource.data.find((breedNode) =>
+      breedNode.children?.some((child) => child.data === osVersion),
+    );
+
+    if (!targetBreed) return;
+
+    const breedFlatNode = this.treeControl.dataNodes.find(
+      (node) => node.data === targetBreed.data,
+    );
+    if (breedFlatNode) {
+      this.treeControl.expand(breedFlatNode);
+    }
+
+    const osVersionFlatNode = this.treeControl.dataNodes.find(
+      (node) => node.data === osVersion,
+    );
+    if (osVersionFlatNode) {
+      this.treeControl.expand(osVersionFlatNode);
+    }
+
+    // Scrolls to the target table after it's rendered in 150ms.
+    setTimeout(() => {
+      const element = document.getElementById('node-' + osVersion);
+      if (element) {
+        element.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+        });
+      }
+    }, 150);
   }
 }


### PR DESCRIPTION
This PR allows users to navigate to the selected item (e.g., OS breed or version) or to display the information of the selected item by clicking on item name. 

Closes #375 
<img width="1384" height="406" alt="image" src="https://github.com/user-attachments/assets/f07ee3a3-7638-43c1-8fa0-56d2c67c526c" />
