### PR TITLE
CI fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,6 @@ updates:
         applies-to: version-updates
         patterns:
           - "@angular*"
-        update-types:
-          - "minor"
-          - "patch"
     commit-message:
       prefix: "build"
       prefix-development: "chore"
@@ -27,13 +24,10 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      dependabot:
+      codeql:
         applies-to: version-updates
         patterns:
           - "github/codeql-action/*"
-        update-types:
-          - "minor"
-          - "patch"
     commit-message:
       prefix: "build"
       prefix-development: "chore"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,6 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This PR prevents automatic releases on pushes and fixes an issue where there are many Dependabot PRs open for Angular.